### PR TITLE
chore: add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,117 @@
+---
+name: "🐛 Bug Report"
+description: Report a bug
+title: "(module name): (short issue description)"
+labels: [bug, needs-triage]
+assignees: []
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the bug
+      description: What is the problem? A clear and concise description of the bug.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: |
+        What did you expect to happen?
+    validations:
+      required: true
+  - type: textarea
+    id: current
+    attributes:
+      label: Current Behavior
+      description: |
+        What actually happened?
+
+        Please include full errors, uncaught exceptions, stack traces, and relevant logs.
+        If service responses are relevant, please include wire logs.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction Steps
+      description: |
+        Provide a self-contained, concise snippet of code that can be used to reproduce the issue.
+        For more complex issues provide a repo with the smallest sample that reproduces the bug.
+
+        Avoid including business logic or unrelated code, it makes diagnosis more difficult.
+        The code sample should be an SSCCE. See http://sscce.org/ for details. In short, please provide a code sample that we can copy/paste, run and reproduce.
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Possible Solution
+      description: |
+        Suggest a fix/reason for the bug
+    validations:
+      required: false
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Information/Context
+      description: |
+        Anything else that might be relevant for troubleshooting this bug. Providing context helps us come up with a solution that is most useful in the real world.
+    validations:
+      required: false
+
+  - type: input
+    id: cdk-version
+    attributes:
+      label: CDK CLI Version
+      description: Output of `cdk version`
+    validations:
+      required: true
+
+  - type: input
+    id: framework-version
+    attributes:
+      label: Framework Version
+    validations:
+      required: false
+
+  - type: input
+    id: node-version
+    attributes:
+      label: Node.js Version
+    validations:
+      required: true
+
+  - type: input
+    id: operating-system
+    attributes:
+      label: OS
+    validations:
+      required: true
+
+  - type: dropdown
+    id: language
+    attributes:
+      label: Language
+      multiple: true
+      options:
+        - TypeScript
+    validations:
+      required: true
+
+  - type: input
+    id: language-version
+    attributes:
+      label: Language Version
+      description: E.g. TypeScript (3.8.3) | Java (8) | Python (3.7.3)
+    validations:
+      required: false
+
+  - type: textarea
+    id: other
+    attributes:
+      label: Other information
+      description: |
+        e.g. detailed explanation, stacktraces, related issues, suggestions how to fix, links for us to have context, eg. associated pull-request, stackoverflow, slack, etc
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,6 @@
+---
+blank_issues_enabled: false
+contact_links:
+  - name: 💬 General Question
+    url: https://github.com/aws/aws-cdk/discussions/categories/q-a
+    about: Please ask and answer questions as a discussion thread

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,23 @@
+---
+name: "📕 Documentation Issue"
+description: Report an issue in the API Reference documentation or Developer Guide
+title: "(module name): (short issue description)"
+labels: [documentation, needs-triage]
+assignees: []
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the issue
+      description: A clear and concise description of the issue.
+    validations:
+      required: true
+
+  - type: textarea
+    id: links
+    attributes:
+      label: Links
+      description: |
+        Include links to affected documentation page(s).
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,59 @@
+---
+name: 🚀 Feature Request
+description: Suggest an idea for this project
+title: "(module name): (short issue description)"
+labels: [feature-request, needs-triage]
+assignees: []
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the feature
+      description: A clear and concise description of the feature you are proposing.
+    validations:
+      required: true
+  - type: textarea
+    id: use-case
+    attributes:
+      label: Use Case
+      description: |
+        Why do you need this feature? For example: "I'm always frustrated when..."
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: |
+        Suggest how to implement the addition or change. Please include prototype/workaround/sketch/reference implementation.
+    validations:
+      required: false
+  - type: textarea
+    id: other
+    attributes:
+      label: Other Information
+      description: |
+        Any alternative solutions or features you considered, a more detailed explanation, stack traces, related issues, links for context, etc.
+    validations:
+      required: false
+  - type: checkboxes
+    id: ack
+    attributes:
+      label: Acknowledgements
+      options:
+        - label: I may be able to implement this feature request
+          required: false
+        - label: This feature might incur a breaking change
+          required: false
+  - type: input
+    id: sdk-version
+    attributes:
+      label: CDK version used
+    validations:
+      required: true
+  - type: input
+    id: environment
+    attributes:
+      label: Environment details (OS name and version, etc.)
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/notice.yml
+++ b/.github/ISSUE_TEMPLATE/notice.yml
@@ -1,0 +1,58 @@
+---
+name: "❗ Notice"
+description: Post a notice for a high impact issue
+title: "❗ NOTICE (module name): (short notice description)"
+labels: [p0, management/tracking]
+body:
+  - type: dropdown
+    attributes:
+      label: Status
+      description: What is the current status of this issue?
+      options:
+        - Investigating (Default)
+        - In-Progress
+        - Resolved
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: What is the issue?
+      description: A clear and concise description of the issue you want customers to be aware of
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Error message
+      description: If available, paste the error message users are seeing (no need to backticks)
+      render: console
+  - type: textarea
+    attributes:
+      label: What is the impact?
+      description: |
+        What can occur if this issue isn't addressed?
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Workaround
+      description: |
+        Please provide a detailed workaround outlining all steps required for implementation. If none exist yet, leave blank
+  - type: textarea
+    attributes:
+      label: Who is affected?
+      description: |
+        What segment of customers are affected? Think about specific construct usage, version, feature toggles, etc...
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: How do I resolve this?
+      description: |
+        What actions should customers take to resolve the issue. Also elaborate on any code changes the customer may need to do. If unknown yet, say TBD
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Related issues
+      description: |
+        List all related issues here. If none related, leave blank

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,23 @@
-Fixes #
+### Issue # (if applicable)
+
+Closes #<issue number here>.
+
+### Reason for this change
+
+<!--What is the bug or use case behind this change?-->
+
+### Description of changes
+
+<!--What code changes did you make? Have you made any important design decisions?-->
+
+### Description of how you validated changes
+
+<!--Have you added any unit tests and/or integration tests?-->
+
+### Checklist
+
+- [ ] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/sbt-aws/blob/main/CONTRIBUTING.md)
 
 ---
-By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the project license.
+
+*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the project license.*

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,22 +1,4 @@
-### Issue # (if applicable)
+Fixes #
 
-Closes #<issue number here>.
-
-### Reason for this change
-
-<!--What is the bug or use case behind this change?-->
-
-### Description of changes
-
-<!--What code changes did you make? Have you made any important design decisions?-->
-
-### Description of how you validated changes
-
-<!--Have you added any unit tests and/or integration tests?-->
-
-### Checklist
-- [ ] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)
-
-----
-
-*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
+---
+By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the project license.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,22 @@
-Fixes #
+### Issue # (if applicable)
 
----
-By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the project license.
+Closes #<issue number here>.
+
+### Reason for this change
+
+<!--What is the bug or use case behind this change?-->
+
+### Description of changes
+
+<!--What code changes did you make? Have you made any important design decisions?-->
+
+### Description of how you validated changes
+
+<!--Have you added any unit tests and/or integration tests?-->
+
+### Checklist
+- [ ] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)
+
+----
+
+*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

--- a/.github/workflows/pull-request-lint.yml
+++ b/.github/workflows/pull-request-lint.yml
@@ -33,7 +33,9 @@ jobs:
       pull-requests: read
     env:
       PR_BODY: ${{ github.event.pull_request.body }}
-      EXPECTED: By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the project license.
+      EXPECTED: |-
+        
+        *By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the project license.*
       HELP: Contributor statement missing from PR description. Please include the following text in the PR description
     if: "!(github.event.pull_request.user.login == 'amazon-auto' || github.event.pull_request.user.login == 'dependabot[bot]' || github.event.pull_request.user.login == 'github-actions')"
     steps:

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -37,6 +37,27 @@ const project = new awscdk.AwsCdkConstructLibrary({
   prettier: true,
   projenrcTs: true,
   projenVersion: PROJEN_VERSION,
+  pullRequestTemplateContents: [
+    '### Issue # (if applicable)',
+    '',
+    'Closes #<issue number here>.',
+    '',
+    '### Reason for this change',
+    '',
+    '<!--What is the bug or use case behind this change?-->',
+    '',
+    '### Description of changes',
+    '',
+    '<!--What code changes did you make? Have you made any important design decisions?-->',
+    '',
+    '### Description of how you validated changes',
+    '',
+    '<!--Have you added any unit tests and/or integration tests?-->',
+    '',
+    '### Checklist',
+    '',
+    '- [ ] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/sbt-aws/blob/main/CONTRIBUTING.md)',
+  ],
   repositoryUrl: `https://github.com/${GITHUB_USER}/${PROJECT_NAME}`,
   sampleCode: false,
   stability: 'experimental',
@@ -44,14 +65,13 @@ const project = new awscdk.AwsCdkConstructLibrary({
 
   npmTokenSecret: 'NPM_TOKEN',
   npmAccess: NpmAccess.PUBLIC,
-
   githubOptions: {
     projenCredentials: GithubCredentials.fromPersonalAccessToken({
       secret: 'GITHUB_TOKEN',
     }),
     pullRequestLintOptions: {
       contributorStatement:
-        'By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the project license.',
+        '\n*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the project license.*',
       contributorStatementOptions: {
         exemptUsers: ['amazon-auto', 'dependabot[bot]', 'github-actions'],
       },


### PR DESCRIPTION
Added issue templates. Copied, mostly, from aws-cdk.
---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the project license.
