### PR TITLE
chore: update secret name

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.PROJEN_GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
       - name: Download patch

--- a/.github/workflows/upgrade-main.yml
+++ b/.github/workflows/upgrade-main.yml
@@ -65,7 +65,7 @@ jobs:
         id: create-pr
         uses: peter-evans/create-pull-request@v6
         with:
-          token: ${{ secrets.PROJEN_GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: |-
             chore(deps): upgrade dependencies
 

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -36,6 +36,7 @@ const project = new awscdk.AwsCdkConstructLibrary({
   prettier: true,
   projenrcTs: true,
   projenVersion: PROJEN_VERSION,
+  projenTokenSecret: 'GITHUB_TOKEN',
   repositoryUrl: `https://github.com/${GITHUB_USER}/${PROJECT_NAME}`,
   sampleCode: false,
   stability: 'experimental',

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { awscdk, javascript } from 'projen';
+import { GithubCredentials } from 'projen/lib/github';
 import { NpmAccess } from 'projen/lib/javascript';
 
 const GITHUB_USER = 'awslabs';
@@ -36,7 +37,6 @@ const project = new awscdk.AwsCdkConstructLibrary({
   prettier: true,
   projenrcTs: true,
   projenVersion: PROJEN_VERSION,
-  projenTokenSecret: 'GITHUB_TOKEN',
   repositoryUrl: `https://github.com/${GITHUB_USER}/${PROJECT_NAME}`,
   sampleCode: false,
   stability: 'experimental',
@@ -46,6 +46,9 @@ const project = new awscdk.AwsCdkConstructLibrary({
   npmAccess: NpmAccess.PUBLIC,
 
   githubOptions: {
+    projenCredentials: GithubCredentials.fromPersonalAccessToken({
+      secret: 'GITHUB_TOKEN',
+    }),
     pullRequestLintOptions: {
       contributorStatement:
         'By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the project license.',


### PR DESCRIPTION
Some of the projen workflows require repo access for mutation. I think this can be accomplished with the GITHUB_TOKEN vs. the PROJEN_GITHUB_TOKEN.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the project license.
