### PR TITLE
docs: Readme navigation fix for roadmap link

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Jump To:
 [Getting Started](#getting-started) |
 [Getting Help](#getting-help) |
 [Contributing](#contributing) |
-[Roadmap](https://github.com/aws/aws-cdk/blob/main/ROADMAP.md) |
+[Roadmap](#roadmap) |
 [More Resources](#more-resources)
 
 -------


### PR DESCRIPTION
Fixes the roadmap navigation link inside of the readme to properly point to the roadmap of the SBT readme rather than the CDK. 
---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the project license.
