### PR TITLE
feat: Add CloudFormation telemetry

### DIFF
--- a/src/control-plane/control-plane.ts
+++ b/src/control-plane/control-plane.ts
@@ -13,7 +13,7 @@ import { Services } from './services';
 import { Tables } from './tables';
 import { TenantConfigService } from './tenant-config/tenant-config-service';
 import { DestroyPolicySetter } from '../cdk-aspect/destroy-policy-setter';
-import { EventManager } from '../utils';
+import { EventManager, setTemplateDesc } from '../utils';
 
 export interface ControlPlaneProps {
   readonly applicationPlaneEventSource: string;
@@ -33,6 +33,8 @@ export class ControlPlane extends Construct {
 
   constructor(scope: Construct, id: string, props: ControlPlaneProps) {
     super(scope, id);
+    setTemplateDesc(this, 'SaaS Builder Toolkit - CoreApplicationPlane (uksb-1tupboc57)');
+
     cdk.Aspects.of(this).add(new DestroyPolicySetter());
 
     const messaging = new Messaging(this, 'messaging-stack');

--- a/src/core-app-plane/core-app-plane.ts
+++ b/src/core-app-plane/core-app-plane.ts
@@ -8,7 +8,7 @@ import { Construct } from 'constructs';
 import { BashJobOrchestrator } from './bash-job-orchestrator';
 import { BashJobRunner } from './bash-job-runner';
 import { DestroyPolicySetter } from '../cdk-aspect/destroy-policy-setter';
-import { EventManager } from '../utils';
+import { EventManager, setTemplateDesc } from '../utils';
 
 /**
  * Provides metadata for outgoing events.
@@ -133,6 +133,8 @@ export interface CoreApplicationPlaneProps {
 export class CoreApplicationPlane extends Construct {
   constructor(scope: Construct, id: string, props: CoreApplicationPlaneProps) {
     super(scope, id);
+    setTemplateDesc(this, 'SaaS Builder Toolkit - CoreApplicationPlane (uksb-1tupboc57)');
+
     cdk.Aspects.of(this).add(new DestroyPolicySetter());
 
     const eventBus = EventBus.fromEventBusArn(this, 'eventBus', props.eventBusArn);

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -2,3 +2,4 @@
 // SPDX-License-Identifier: Apache-2.0
 
 export * from './event-manager';
+export * from './utils';

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,0 +1,11 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Stack } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+
+export const setTemplateDesc = (construct: Construct, sbtDesc: string) => {
+  const stackDesc = Stack.of(construct).templateOptions.description;
+  let description = stackDesc === undefined ? sbtDesc : stackDesc + ' - ' + sbtDesc;
+  Stack.of(construct).templateOptions.description = description;
+};

--- a/test/control-plane.test.ts
+++ b/test/control-plane.test.ts
@@ -117,7 +117,7 @@ describe('ControlPlane without Description', () => {
   it('should have a fixed template description, when the containing stack does not have description', () => {
     const actual = controlPlaneTestStack.templateOptions.description;
     const expected = 'SaaS Builder Toolkit - CoreApplicationPlane (uksb-1tupboc57)';
-    expect(actual == expected);
+    expect(actual).toStrictEqual(expected);
   });
 
   it('should have a concatenated template description, when the containing stack has an existing desc', () => {
@@ -127,6 +127,6 @@ describe('ControlPlane without Description', () => {
     });
     const actual = stackWithDescription.templateOptions.description;
     const expected = 'ABC - SaaS Builder Toolkit - CoreApplicationPlane (uksb-1tupboc57)';
-    expect(expected === actual);
+    expect(expected).toStrictEqual(actual);
   });
 });

--- a/test/control-plane.test.ts
+++ b/test/control-plane.test.ts
@@ -1,7 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { assert } from 'console';
 import * as cdk from 'aws-cdk-lib';
 import { Annotations, Match, Template, Capture } from 'aws-cdk-lib/assertions';
 import { AwsSolutionsChecks } from 'cdk-nag';
@@ -118,7 +117,7 @@ describe('ControlPlane without Description', () => {
   it('should have a fixed template description, when the containing stack does not have description', () => {
     const actual = controlPlaneTestStack.templateOptions.description;
     const expected = 'SaaS Builder Toolkit - CoreApplicationPlane (uksb-1tupboc57)';
-    assert(actual == expected);
+    expect(actual == expected);
   });
 
   it('should have a concatenated template description, when the containing stack has an existing desc', () => {
@@ -128,6 +127,6 @@ describe('ControlPlane without Description', () => {
     });
     const actual = stackWithDescription.templateOptions.description;
     const expected = 'ABC - SaaS Builder Toolkit - CoreApplicationPlane (uksb-1tupboc57)';
-    assert(expected === actual);
+    expect(expected === actual);
   });
 });

--- a/test/control-plane.test.ts
+++ b/test/control-plane.test.ts
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { assert } from 'console';
 import * as cdk from 'aws-cdk-lib';
 import { Annotations, Match, Template, Capture } from 'aws-cdk-lib/assertions';
 import { AwsSolutionsChecks } from 'cdk-nag';
@@ -59,7 +60,7 @@ describe('No unsuppressed cdk-nag Warnings or Errors', () => {
   });
 });
 
-describe('ControlPlane', () => {
+describe('ControlPlane without Description', () => {
   const app = new cdk.App();
   interface TestStackProps extends cdk.StackProps {
     systemAdminEmail: string;
@@ -112,5 +113,21 @@ describe('ControlPlane', () => {
     do {
       expect(targetsCapture.asArray()).toHaveLength(1);
     } while (targetsCapture.next());
+  });
+
+  it('should have a fixed template description, when the containing stack does not have description', () => {
+    const actual = controlPlaneTestStack.templateOptions.description;
+    const expected = 'SaaS Builder Toolkit - CoreApplicationPlane (uksb-1tupboc57)';
+    assert(actual == expected);
+  });
+
+  it('should have a concatenated template description, when the containing stack has an existing desc', () => {
+    const stackWithDescription = new TestStack(app, 'stackWithDescription', {
+      systemAdminEmail: 'test@example.com',
+      description: 'ABC',
+    });
+    const actual = stackWithDescription.templateOptions.description;
+    const expected = 'ABC - SaaS Builder Toolkit - CoreApplicationPlane (uksb-1tupboc57)';
+    assert(expected === actual);
   });
 });


### PR DESCRIPTION
### Reason for this change

Adds internal telemetry for CloudFormation

### Description of changes

* Added a function that will set the template description, and called the function from both ControlPlane and CoreApplicationPlane

### Description of how you validated changes

Added unit tests. Util function has 100% coverage.

### Checklist

- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/sbt-aws/blob/main/CONTRIBUTING.md)

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the project license.*
