### PR TITLE
fix: check existence of tenant before updating

### DIFF
--- a/scripts/test-sbt-aws.sh
+++ b/scripts/test-sbt-aws.sh
@@ -160,6 +160,18 @@ else
     log_test "fail" "Failed to delete tenant"
 fi
 
+# Test deleting a non-existent tenant
+echo "Testing delete-tenant for non-existent tenant..."
+fake_tenant_id=$(openssl rand -hex 10)
+delete_output=$(./sbt-aws.sh delete-tenant "$fake_tenant_id" 2>&1)
+delete_response=$(echo "$delete_output" | jq -r '.')
+
+if [ "$(echo "$delete_response" | jq -r '.statusCode')" = "404" ] && [ "$(echo "$delete_response" | jq -r '.message')" = "Tenant '$fake_tenant_id' not found." ]; then
+    log_test "pass" "Received expected error when deleting non-existent tenant"
+else
+    log_test "fail" "Unexpected output when deleting non-existent tenant"
+fi
+
 # Set the exit code based on the overall test status
 if [ "$TEST_PASSED" = true ]; then
     exit 0


### PR DESCRIPTION
### Issue # (if applicable)

Closes #8 

### Reason for this change

<!--What is the bug or use case behind this change?-->

### Description of changes

Check if tenant id exists before updating the tenant.

### Description of how you validated changes

<!--Have you added any unit tests and/or integration tests?-->

### Checklist

- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/sbt-aws/blob/main/CONTRIBUTING.md)

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the project license.*
