### PR TITLE
feat: Interface updates for billing user Read and Update operations

### DIFF
--- a/src/control-plane/billing/billing-interface.ts
+++ b/src/control-plane/billing/billing-interface.ts
@@ -19,6 +19,16 @@ export interface IBilling {
   deleteUserFunction: IFunction;
 
   /**
+   * The function to trigger when updating a billing user.
+   */
+  updateUserFunction: IFunction;
+
+  /**
+   * The function to trigger when getting a billing user. 
+   */
+  getUserFunction: IFunction;
+
+  /**
    * The IDataIngestorAggregator responsible for accepting and aggregating
    * the raw billing data.
    */

--- a/src/control-plane/billing/billing-interface.ts
+++ b/src/control-plane/billing/billing-interface.ts
@@ -26,7 +26,7 @@ export interface IBilling {
   /**
    * The function to trigger when getting a billing user. 
    */
-  getUserFunction: IFunction;
+  readUserFunction: IFunction;
 
   /**
    * The IDataIngestorAggregator responsible for accepting and aggregating


### PR DESCRIPTION

### Reason for this change

Based on prior discussions we wanted to discuss the billing interface further. The Billing interface as is, cannot handle changing a customer's enrollment in an offering, without the full deletion and then creation of a new customer. Ideally, a SaaS customer should be able to upgrade their offering seemlessly, and the billing integration should have options to handle this. 

Additionally, if a SaaS customer needs to update their Billing Address, Business Name etc... without an update function this is not a very seamless operation and would require a lot of back channel work. 

Finally, there are cases where the SaaS business will want to read the state of the SaaS customer, and then have application level changes. such as displaying a banner, stopping the creation of additional resources, or pausing the  use of currently running resources. Without a read function, understanding current state of the SaaS customer is difficult to determine for the SaaS business. 

### Description of changes

I have added two new `IFunctions` to the `IBilling` interface. `readUserFunction` and `updateUserFunction`. 

### Description of how you validated changes

These are added interface changes, there are no tests inside the repo currently testing the billing interface, so I did not add any. 

### Checklist

- [ x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/sbt-aws/blob/main/CONTRIBUTING.md)

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the project license.*
