### PR TITLE
fix: Fix for 19

### DIFF
--- a/API.md
+++ b/API.md
@@ -2443,6 +2443,7 @@ const controlPlaneAPIProps: ControlPlaneAPIProps = { ... }
 | <code><a href="#@cdklabs/sbt-aws.ControlPlaneAPIProps.property.auth">auth</a></code> | <code><a href="#@cdklabs/sbt-aws.IAuth">IAuth</a></code> | *No description.* |
 | <code><a href="#@cdklabs/sbt-aws.ControlPlaneAPIProps.property.services">services</a></code> | <code><a href="#@cdklabs/sbt-aws.Services">Services</a></code> | *No description.* |
 | <code><a href="#@cdklabs/sbt-aws.ControlPlaneAPIProps.property.tenantConfigServiceLambda">tenantConfigServiceLambda</a></code> | <code>aws-cdk-lib.aws_lambda.Function</code> | *No description.* |
+| <code><a href="#@cdklabs/sbt-aws.ControlPlaneAPIProps.property.disableAPILogging">disableAPILogging</a></code> | <code>boolean</code> | *No description.* |
 
 ---
 
@@ -2476,6 +2477,16 @@ public readonly tenantConfigServiceLambda: Function;
 
 ---
 
+##### `disableAPILogging`<sup>Optional</sup> <a name="disableAPILogging" id="@cdklabs/sbt-aws.ControlPlaneAPIProps.property.disableAPILogging"></a>
+
+```typescript
+public readonly disableAPILogging: boolean;
+```
+
+- *Type:* boolean
+
+---
+
 ### ControlPlaneProps <a name="ControlPlaneProps" id="@cdklabs/sbt-aws.ControlPlaneProps"></a>
 
 #### Initializer <a name="Initializer" id="@cdklabs/sbt-aws.ControlPlaneProps.Initializer"></a>
@@ -2494,6 +2505,7 @@ const controlPlaneProps: ControlPlaneProps = { ... }
 | <code><a href="#@cdklabs/sbt-aws.ControlPlaneProps.property.applicationPlaneEventSource">applicationPlaneEventSource</a></code> | <code>string</code> | The source to use for outgoing events that will be placed on the EventBus. |
 | <code><a href="#@cdklabs/sbt-aws.ControlPlaneProps.property.billing">billing</a></code> | <code><a href="#@cdklabs/sbt-aws.IBilling">IBilling</a></code> | *No description.* |
 | <code><a href="#@cdklabs/sbt-aws.ControlPlaneProps.property.controlPlaneEventSource">controlPlaneEventSource</a></code> | <code>string</code> | The source to use when listening for events coming from the SBT control plane. |
+| <code><a href="#@cdklabs/sbt-aws.ControlPlaneProps.property.disableAPILogging">disableAPILogging</a></code> | <code>boolean</code> | (Optional) If true, the API Gateway will not log requests to the CloudWatch Logs. |
 | <code><a href="#@cdklabs/sbt-aws.ControlPlaneProps.property.eventMetadata">eventMetadata</a></code> | <code>{[ key: string ]: string}</code> | *No description.* |
 
 ---
@@ -2543,6 +2555,20 @@ public readonly controlPlaneEventSource: string;
 The source to use when listening for events coming from the SBT control plane.
 
 This is used as the default if the IncomingEventMetadata source field is not set.
+
+---
+
+##### `disableAPILogging`<sup>Optional</sup> <a name="disableAPILogging" id="@cdklabs/sbt-aws.ControlPlaneProps.property.disableAPILogging"></a>
+
+```typescript
+public readonly disableAPILogging: boolean;
+```
+
+- *Type:* boolean
+
+(Optional) If true, the API Gateway will not log requests to the CloudWatch Logs.
+
+(Default: false)
 
 ---
 

--- a/docs/public/README.md
+++ b/docs/public/README.md
@@ -76,6 +76,9 @@ The "objects" present in this example were written by the CDK team. Specifically
 
 ### Tutorial
 
+> [!WARNING]
+> Running this tutorial may incur charges in your AWS account.
+
 As mentioned before, SBT is built on top of CDK. To illustrate its use, please first follow the CDK getting started guide to initialize a new CDK application. You can find the guide [here](https://docs.aws.amazon.com/cdk/v2/guide/hello_world.html#hello_world_tutorial_create_app). Please complete step one of the **hello cdk** tutorial then come back here to continue with SBT. Again, you don't need to build or deploy the sample app; just create it for now.
 
 Now that you've initialized a new CDK app, let's install the SBT components. From within the `hello-cdk` directory, please run the following command:
@@ -105,8 +108,11 @@ export class ControlPlaneStack extends Stack {
       systemAdminEmail: 'ENTER YOUR EMAIL HERE',
     });
 
-    const controlPlane = new ControlPlane(this, 'ControlPlane', {
+  // NOTE: To explicitly disable cloudwatch logging (and potentially save costs on CloudWatch), 
+  // pass the disableAPILogging flag as true
+  const controlPlane = new ControlPlane(this, 'ControlPlane', {
       auth: cognitoAuth,
+      //disableAPILogging: true
     });
     this.eventBusArn = controlPlane.eventBusArn;
     this.regApiGatewayUrl = controlPlane.controlPlaneAPIGatewayUrl;

--- a/src/control-plane/control-plane.ts
+++ b/src/control-plane/control-plane.ts
@@ -30,6 +30,12 @@ export interface ControlPlaneProps {
    * This is used as the default if the OutgoingEventMetadata source field is not set.
    */
   readonly applicationPlaneEventSource?: string;
+
+  /**
+   * (Optional) If true, the API Gateway will not log requests to the CloudWatch Logs.
+   * (Default: false)
+   */
+  readonly disableAPILogging?: boolean;
 }
 
 export class ControlPlane extends Construct {
@@ -68,8 +74,9 @@ export class ControlPlane extends Construct {
     });
 
     const controlPlaneAPI = new ControlPlaneAPI(this, 'controlplane-api-stack', {
-      services: services,
       auth: props.auth,
+      disableAPILogging: props.disableAPILogging,
+      services: services,
       tenantConfigServiceLambda: tenantConfigService.tenantConfigServiceLambda,
     });
 

--- a/test/control-plane.test.ts
+++ b/test/control-plane.test.ts
@@ -48,33 +48,35 @@ describe('No unsuppressed cdk-nag Warnings or Errors', () => {
   });
 });
 
-describe('ControlPlane', () => {
-  const app = new cdk.App();
-  interface TestStackProps extends cdk.StackProps {
-    systemAdminEmail: string;
+const app = new cdk.App();
+interface TestStackProps extends cdk.StackProps {
+  systemAdminEmail: string;
+  disableAPILogging?: boolean;
+}
+class TestStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props: TestStackProps) {
+    super(scope, id, props);
+
+    // for event bridge communication
+    const idpName = 'COGNITO';
+    const systemAdminRoleName = 'SystemAdmin';
+
+    const cognitoAuth = new CognitoAuth(this, 'CognitoAuth', {
+      idpName: idpName,
+      systemAdminRoleName: systemAdminRoleName,
+      systemAdminEmail: props.systemAdminEmail,
+      // optional parameter possibly populated by another construct or an argument
+      // controlPlaneCallbackURL: 'https://example.com',
+    });
+
+    new ControlPlane(this, 'ControlPlane', {
+      auth: cognitoAuth,
+      disableAPILogging: props.disableAPILogging,
+    });
   }
-  class TestStack extends cdk.Stack {
-    constructor(scope: cdk.App, id: string, props: TestStackProps) {
-      super(scope, id, props);
+}
 
-      // for event bridge communication
-      const idpName = 'COGNITO';
-      const systemAdminRoleName = 'SystemAdmin';
-
-      const cognitoAuth = new CognitoAuth(this, 'CognitoAuth', {
-        idpName: idpName,
-        systemAdminRoleName: systemAdminRoleName,
-        systemAdminEmail: props.systemAdminEmail,
-        // optional parameter possibly populated by another construct or an argument
-        // controlPlaneCallbackURL: 'https://example.com',
-      });
-
-      new ControlPlane(this, 'ControlPlane', {
-        auth: cognitoAuth,
-      });
-    }
-  }
-
+describe('ControlPlane Targets', () => {
   const controlPlaneTestStack = new TestStack(app, 'appPlaneStack', {
     systemAdminEmail: 'test@example.com',
   });
@@ -92,9 +94,14 @@ describe('ControlPlane', () => {
       expect(targetsCapture.asArray()).toHaveLength(1);
     } while (targetsCapture.next());
   });
+});
 
+describe('ControlPlane description', () => {
   it('should have a fixed template description, when the containing stack does not have description', () => {
-    const actual = controlPlaneTestStack.templateOptions.description;
+    const stackWithoutDescription = new TestStack(app, 'stackWithoutDescription', {
+      systemAdminEmail: 'test@example.com',
+    });
+    const actual = stackWithoutDescription.templateOptions.description;
     const expected = 'SaaS Builder Toolkit - CoreApplicationPlane (uksb-1tupboc57)';
     expect(actual).toStrictEqual(expected);
   });
@@ -107,5 +114,71 @@ describe('ControlPlane', () => {
     const actual = stackWithDescription.templateOptions.description;
     const expected = 'ABC - SaaS Builder Toolkit - CoreApplicationPlane (uksb-1tupboc57)';
     expect(expected).toStrictEqual(actual);
+  });
+});
+
+describe('ControlPlane cloudwatch roles', () => {
+  it('should create the cloudwatch IAM apigw push to cw role by default', () => {
+    const stackWithLogging = new TestStack(new cdk.App(), 'stackWithLogging', {
+      systemAdminEmail: 'test@example.com',
+    });
+    const template = Template.fromStack(stackWithLogging);
+    template.hasResourceProperties(
+      'AWS::IAM::Role',
+      Match.objectLike({
+        AssumeRolePolicyDocument: {
+          Statement: [
+            {
+              Action: 'sts:AssumeRole',
+              Effect: 'Allow',
+              Principal: {
+                Service: 'apigateway.amazonaws.com',
+              },
+            },
+          ],
+          Version: '2012-10-17',
+        },
+        ManagedPolicyArns: [
+          {
+            'Fn::Join': [
+              '',
+              [
+                'arn:',
+                {
+                  Ref: 'AWS::Partition',
+                },
+                ':iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs',
+              ],
+            ],
+          },
+        ],
+      })
+    );
+  });
+
+  it('should not create the cloudwatch IAM publishing role if the disable logging flag is true', () => {
+    const stackWithoutLogging = new TestStack(new cdk.App(), 'stackWithoutLogging', {
+      systemAdminEmail: 'test@example.com',
+      disableAPILogging: true,
+    });
+    const templateWithoutLogging = Template.fromStack(stackWithoutLogging);
+    templateWithoutLogging.resourcePropertiesCountIs(
+      'AWS::IAM::Role',
+      {
+        AssumeRolePolicyDocument: {
+          Statement: [
+            {
+              Action: 'sts:AssumeRole',
+              Effect: 'Allow',
+              Principal: {
+                Service: 'apigateway.amazonaws.com',
+              },
+            },
+          ],
+          Version: '2012-10-17',
+        },
+      },
+      0
+    );
   });
 });


### PR DESCRIPTION
Now explicitly creates the IAM Role allowing APIGW to publish to CloudWatch. Customers can opt out by passing the `disableAPILogging` property to the ControlPlane props

### Issue # 19

Closes #19

### Reason for this change

Deployment into a fresh account fails without this change. Now creates the rest API construct with a flag to explicitly create the IAM Role that allows API GW to push to CloudWatch.

### Description of changes

Added a new field to the `ControlPlaneProps` called `disableAPILogging`. It's optional with a default of false. Also modified docs to surface this change.

### Description of how you validated changes
Wrote unit tests to validate the synthed template with and without the flag.

### Checklist

- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/sbt-aws/blob/main/CONTRIBUTING.md)

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the project license.*
