### PR TITLE
fix: Point solutions release github action 

### DIFF
--- a/.github/workflows/release_cdklabs-sbt-point-solutions-lib.yml
+++ b/.github/workflows/release_cdklabs-sbt-point-solutions-lib.yml
@@ -35,6 +35,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
         working-directory: ./
+      - name: Install Dependencies
+        run: npm ci
       - name: release
         run: npx projen release
       - name: Check if version has already been tagged

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -137,6 +137,12 @@ const jsiiLibraryProjectOptions: cdk.JsiiProjectOptions = {
     ],
   },
   release: true,
+  releaseWorkflowSetupSteps: [
+    {
+      name: 'Install Dependencies',
+      run: 'npm ci',
+    }
+  ],
   bundledDeps: [
     '@aws-sdk/client-sts',
     '@aws-sdk/client-ssm',

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -141,7 +141,7 @@ const jsiiLibraryProjectOptions: cdk.JsiiProjectOptions = {
     {
       name: 'Install Dependencies',
       run: 'npm ci',
-    }
+    },
   ],
   bundledDeps: [
     '@aws-sdk/client-sts',


### PR DESCRIPTION
### Issue # (if applicable)

Closes #<issue number here>.

### Reason for this change

The auto generated sub project release github action is not installing dependencies from sub project.

### Description of changes

Updated the sub project release github action, by adding a job to install dependencies from sub project.

### Description of how you validated changes

Generated sub project release github action now uses sub project folder location

### Checklist

- [X] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/sbt-aws/blob/main/CONTRIBUTING.md)

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the project license.*
