### PR TITLE
fix: Added different release tags for sbt components and point solutions

### DIFF
--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -32,7 +32,7 @@
         "CHANGELOG": "dist/changelog.md",
         "BUMPFILE": "dist/version.txt",
         "RELEASETAG": "dist/releasetag.txt",
-        "RELEASE_TAG_PREFIX": ""
+        "RELEASE_TAG_PREFIX": "@cdklabs/sbt-aws"
       },
       "steps": [
         {
@@ -197,7 +197,8 @@
       "name": "release",
       "description": "Prepare a release from \"main\" branch",
       "env": {
-        "RELEASE": "true"
+        "RELEASE": "true",
+        "RELEASE_TAG_PREFIX": "@cdklabs/sbt-aws"
       },
       "steps": [
         {
@@ -247,7 +248,7 @@
         "CHANGELOG": "dist/changelog.md",
         "BUMPFILE": "dist/version.txt",
         "RELEASETAG": "dist/releasetag.txt",
-        "RELEASE_TAG_PREFIX": ""
+        "RELEASE_TAG_PREFIX": "@cdklabs/sbt-aws"
       },
       "steps": [
         {

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -70,6 +70,7 @@ const project = new awscdk.AwsCdkConstructLibrary({
   npmIgnoreOptions: {
     ignorePatterns: NPM_IGNORE_PATTERNS,
   },
+  releaseTagPrefix: '@cdklabs/sbt-aws',
 });
 
 // Add License header automatically
@@ -147,6 +148,7 @@ const jsiiLibraryProjectOptions: cdk.JsiiProjectOptions = {
       run: 'npm ci',
     },
   ],
+  releaseTagPrefix: '@aws/sbt-point-solutions-lib',
   bundledDeps: [
     '@aws-sdk/client-sts',
     '@aws-sdk/client-ssm',

--- a/src/point-solutions/libraries/.projen/tasks.json
+++ b/src/point-solutions/libraries/.projen/tasks.json
@@ -29,7 +29,7 @@
         "CHANGELOG": "dist/changelog.md",
         "BUMPFILE": "dist/version.txt",
         "RELEASETAG": "dist/releasetag.txt",
-        "RELEASE_TAG_PREFIX": ""
+        "RELEASE_TAG_PREFIX": "@aws/sbt-point-solutions-lib"
       },
       "steps": [
         {
@@ -151,7 +151,8 @@
       "name": "release",
       "description": "Prepare a release from \"main\" branch",
       "env": {
-        "RELEASE": "true"
+        "RELEASE": "true",
+        "RELEASE_TAG_PREFIX": "@aws/sbt-point-solutions-lib"
       },
       "steps": [
         {
@@ -201,7 +202,7 @@
         "CHANGELOG": "dist/changelog.md",
         "BUMPFILE": "dist/version.txt",
         "RELEASETAG": "dist/releasetag.txt",
-        "RELEASE_TAG_PREFIX": ""
+        "RELEASE_TAG_PREFIX": "@aws/sbt-point-solutions-lib"
       },
       "steps": [
         {


### PR DESCRIPTION
### Issue # (if applicable)

Closes #<issue number here>.

### Reason for this change

Since there is only one tag the github actions are publishing to any one npm org

### Description of changes

Added different release tags for sbt components and point solutions 

### Description of how you validated changes

github actions will create different release tags for sbt components and point solutions 

### Checklist

- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/sbt-aws/blob/main/CONTRIBUTING.md)

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the project license.*
