### PR TITLE
feat: Updated tenant-config API

### DIFF
--- a/resources/functions/tenant-config/index.py
+++ b/resources/functions/tenant-config/index.py
@@ -30,7 +30,7 @@ tenant_config_column = os.environ['TENANT_CONFIG_COLUMN']
 tenant_details_table_handler = dynamodb.Table(tenant_details_table)
 
 
-def _get_tenant_config(name):
+def _get_tenant_config_by_name(name):
     response = tenant_details_table_handler.query(
         IndexName=tenant_config_index_name,
         KeyConditionExpression=Key(tenant_name_column).eq(name),
@@ -41,16 +41,44 @@ def _get_tenant_config(name):
     tenant_config = response["Items"][0]
     return tenant_config.get(tenant_config_column, None)
 
+def _get_tenant_config_by_id(id):
+    logger.info(f"id: {id}")
+    response = tenant_details_table_handler.get_item(
+        Key={
+            'tenantId': id
+        },
+    )
+    if "Item" not in response or len(response["Item"]) < 1:
+        return None
 
-def _get_tenant_config_for_tenant(name):
+    tenant_config = response["Item"]
+    return tenant_config.get(tenant_config_column, None)
+
+
+def _get_tenant_config_for_tenant_name(name):
     try:
-        tenant_config = _get_tenant_config(name)
+        tenant_config = _get_tenant_config_by_name(name)
         logger.info(f"tenant_config: {tenant_config}")
         if tenant_config is None:
             logger.error(f"No tenant details found for {name}")
             raise NotFoundError(f"No tenant details found for {name}")
         logger.info(
             f"Tenant config found for {name} - {tenant_config}")
+
+        return tenant_config, HTTPStatus.OK.value
+    except botocore.exceptions.ClientError as error:
+        logger.error(error)
+        raise InternalServerError("Unknown error during processing!")
+
+def _get_tenant_config_for_tenant_id(id):
+    try:
+        tenant_config = _get_tenant_config_by_id(id)
+        logger.info(f"tenant_config: {tenant_config}")
+        if tenant_config is None:
+            logger.error(f"No tenant details found for {id}")
+            raise NotFoundError(f"No tenant details found for {id}")
+        logger.info(
+            f"Tenant config found for {id} - {tenant_config}")
 
         return tenant_config, HTTPStatus.OK.value
     except botocore.exceptions.ClientError as error:
@@ -66,12 +94,24 @@ def get_tenant_config_via_req_param(tenant_name):
         logger.error(f"Tenant name not found in path!")
         raise BadRequestError(f"Tenant name not found in path!")
 
-    return _get_tenant_config_for_tenant(tenant_name)
+    return _get_tenant_config_for_tenant_name(tenant_name)
 
 
 @app.get("/tenant-config")
 @tracer.capture_method
-def get_tenant_config_via_header():
+def get_tenant_config_via_param_or_header():
+    tenant_id: str = app.current_event.get_query_string_value(name="tenantId", default_value="")
+    tenant_name: str = ''
+    logger.info(f"tenant_id: {tenant_id}")
+    if tenant_id is None:
+        logger.info(f"No tenantId query parameter found. Looking for tenantName.")
+    else:
+        return _get_tenant_config_for_tenant_id(tenant_id)
+
+    tenant_name = app.current_event.get_query_string_value(name="tenantName", default_value="")
+    if tenant_name is None:
+        logger.info(f"No tenantName query parameter found. Looking at headers.")
+
     origin_header = app.current_event.get_header_value(name="Origin")
     logger.info(f"origin_header: {origin_header}")
     if origin_header is None:
@@ -86,7 +126,7 @@ def get_tenant_config_via_header():
         logger.error(f"Unable to parse tenant name!")
         raise BadRequestError(f"Unable to parse tenant name!")
 
-    return _get_tenant_config_for_tenant(tenant_name)
+    return _get_tenant_config_for_tenant_name(tenant_name)
 
 
 @logger.inject_lambda_context(


### PR DESCRIPTION
Now allows tenant config to be pulled with both tenant name or tenant Id. The original path `/tenant-config/{tenantName}` is unchanged, but added support for the query parameter `tenantId`. Ex: `/tenant-config?tenantId=abc123`

### Reason for this change

The EKS SaaS Reference architecture doesn't have access to the tenant-name, so it needed to be able to resolve tenant auth information based on tenant id.

### Description of changes

The tenant-config python lambda file

### Checklist

- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/sbt-aws/blob/main/CONTRIBUTING.md)

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the project license.*
