### PR TITLE
fix: add cors parameter and rename duplicate construct id names

### DIFF
--- a/API.md
+++ b/API.md
@@ -3414,6 +3414,7 @@ const controlPlaneAPIProps: ControlPlaneAPIProps = { ... }
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
 | <code><a href="#@cdklabs/sbt-aws.ControlPlaneAPIProps.property.auth">auth</a></code> | <code><a href="#@cdklabs/sbt-aws.IAuth">IAuth</a></code> | *No description.* |
+| <code><a href="#@cdklabs/sbt-aws.ControlPlaneAPIProps.property.apiCorsConfig">apiCorsConfig</a></code> | <code>aws-cdk-lib.aws_apigatewayv2.CorsPreflightOptions</code> | Settings for Cors Configuration for the ControlPlane API. |
 | <code><a href="#@cdklabs/sbt-aws.ControlPlaneAPIProps.property.disableAPILogging">disableAPILogging</a></code> | <code>boolean</code> | *No description.* |
 
 ---
@@ -3425,6 +3426,18 @@ public readonly auth: IAuth;
 ```
 
 - *Type:* <a href="#@cdklabs/sbt-aws.IAuth">IAuth</a>
+
+---
+
+##### `apiCorsConfig`<sup>Optional</sup> <a name="apiCorsConfig" id="@cdklabs/sbt-aws.ControlPlaneAPIProps.property.apiCorsConfig"></a>
+
+```typescript
+public readonly apiCorsConfig: CorsPreflightOptions;
+```
+
+- *Type:* aws-cdk-lib.aws_apigatewayv2.CorsPreflightOptions
+
+Settings for Cors Configuration for the ControlPlane API.
 
 ---
 
@@ -3453,6 +3466,7 @@ const controlPlaneProps: ControlPlaneProps = { ... }
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
 | <code><a href="#@cdklabs/sbt-aws.ControlPlaneProps.property.systemAdminEmail">systemAdminEmail</a></code> | <code>string</code> | The email address of the system admin. |
+| <code><a href="#@cdklabs/sbt-aws.ControlPlaneProps.property.apiCorsConfig">apiCorsConfig</a></code> | <code>aws-cdk-lib.aws_apigatewayv2.CorsPreflightOptions</code> | Settings for Cors Configuration for the ControlPlane API. |
 | <code><a href="#@cdklabs/sbt-aws.ControlPlaneProps.property.auth">auth</a></code> | <code><a href="#@cdklabs/sbt-aws.IAuth">IAuth</a></code> | The authentication provider for the control plane. |
 | <code><a href="#@cdklabs/sbt-aws.ControlPlaneProps.property.billing">billing</a></code> | <code><a href="#@cdklabs/sbt-aws.IBilling">IBilling</a></code> | The billing provider configuration. |
 | <code><a href="#@cdklabs/sbt-aws.ControlPlaneProps.property.disableAPILogging">disableAPILogging</a></code> | <code>boolean</code> | If true, the API Gateway will not log requests to the CloudWatch Logs. |
@@ -3471,6 +3485,18 @@ public readonly systemAdminEmail: string;
 - *Type:* string
 
 The email address of the system admin.
+
+---
+
+##### `apiCorsConfig`<sup>Optional</sup> <a name="apiCorsConfig" id="@cdklabs/sbt-aws.ControlPlaneProps.property.apiCorsConfig"></a>
+
+```typescript
+public readonly apiCorsConfig: CorsPreflightOptions;
+```
+
+- *Type:* aws-cdk-lib.aws_apigatewayv2.CorsPreflightOptions
+
+Settings for Cors Configuration for the ControlPlane API.
 
 ---
 

--- a/scripts/sbt-aws.sh
+++ b/scripts/sbt-aws.sh
@@ -37,11 +37,11 @@ generate_credentials() {
 
   CLIENT_ID=$(aws cloudformation describe-stacks \
     --stack-name "$CONTROL_PLANE_STACK_NAME" \
-    --query "Stacks[0].Outputs[?OutputKey=='ControlPlaneIdpClientId'].OutputValue" \
+    --query "Stacks[0].Outputs[?contains(OutputKey,'ControlPlaneIdpClientId')].OutputValue" \
     --output text)
   USER_POOL_ID=$(aws cloudformation describe-stacks \
     --stack-name "$CONTROL_PLANE_STACK_NAME" \
-    --query "Stacks[0].Outputs[?OutputKey=='ControlPlaneIdpUserPoolId'].OutputValue" \
+    --query "Stacks[0].Outputs[?contains(OutputKey,'ControlPlaneIdpUserPoolId')].OutputValue" \
     --output text)
 
   if $DEBUG; then

--- a/src/control-plane/auth/cognito-auth.ts
+++ b/src/control-plane/auth/cognito-auth.ts
@@ -332,7 +332,7 @@ export class CognitoAuth extends Construct implements IAuth {
     const userPoolDomain = new cognito.UserPoolDomain(this, 'UserPoolDomain', {
       userPool: this.userPool,
       cognitoDomain: {
-        domainPrefix: `saascontrolplane-${this.node.addr}`,
+        domainPrefix: `${cdk.Stack.of(this).account}-${this.node.addr}`,
       },
     });
 
@@ -398,12 +398,10 @@ export class CognitoAuth extends Construct implements IAuth {
     // TODO: The caller should be surfacing these, not the implementor
     new cdk.CfnOutput(this, 'ControlPlaneIdpUserPoolId', {
       value: this.userPool.userPoolId,
-      key: 'ControlPlaneIdpUserPoolId',
     });
 
     new cdk.CfnOutput(this, 'ControlPlaneIdpClientId', {
       value: userPoolUserClient.userPoolClientId,
-      key: 'ControlPlaneIdpClientId',
     });
 
     const userManagementExecRole = new Role(this, 'userManagementExecRole', {
@@ -498,7 +496,7 @@ export class CognitoAuth extends Construct implements IAuth {
       ]
     );
 
-    this.createAdminUserFunction = new PythonFunction(scope, 'createAdminUserFunction', {
+    this.createAdminUserFunction = new PythonFunction(this, 'createAdminUserFunction', {
       entry: path.join(__dirname, '../../../resources/functions/auth-custom-resource'),
       runtime: Runtime.PYTHON_3_12,
       index: 'index.py',

--- a/src/control-plane/auth/cognito-auth.ts
+++ b/src/control-plane/auth/cognito-auth.ts
@@ -398,10 +398,12 @@ export class CognitoAuth extends Construct implements IAuth {
     // TODO: The caller should be surfacing these, not the implementor
     new cdk.CfnOutput(this, 'ControlPlaneIdpUserPoolId', {
       value: this.userPool.userPoolId,
+      key: 'ControlPlaneIdpUserPoolId',
     });
 
     new cdk.CfnOutput(this, 'ControlPlaneIdpClientId', {
       value: userPoolUserClient.userPoolClientId,
+      key: 'ControlPlaneIdpClientId',
     });
 
     const userManagementExecRole = new Role(this, 'userManagementExecRole', {

--- a/src/control-plane/control-plane-api.ts
+++ b/src/control-plane/control-plane-api.ts
@@ -22,6 +22,10 @@ export interface APICorsConfig {
 export interface ControlPlaneAPIProps {
   readonly auth: IAuth;
   readonly disableAPILogging?: boolean;
+
+  /**
+   * Settings for Cors Configuration for the ControlPlane API.
+   */
   readonly apiCorsConfig?: APICorsConfig;
 }
 

--- a/src/control-plane/control-plane-api.ts
+++ b/src/control-plane/control-plane-api.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import * as cdk from 'aws-cdk-lib';
-import * as apigateway from 'aws-cdk-lib/aws-apigateway';
 import * as apigatewayV2 from 'aws-cdk-lib/aws-apigatewayv2';
 import * as apigatewayV2Authorizers from 'aws-cdk-lib/aws-apigatewayv2-authorizers';
 import { LogGroup, RetentionDays } from 'aws-cdk-lib/aws-logs';
@@ -11,9 +10,19 @@ import { Construct } from 'constructs';
 import { IAuth } from './auth/auth-interface';
 import { addTemplateTag } from '../utils';
 
+export interface APICorsConfig {
+  readonly allowOrigins?: string[];
+  readonly allowCredentials?: boolean;
+  readonly allowHeaders?: string[];
+  readonly allowMethods?: apigatewayV2.CorsHttpMethod[];
+  readonly maxAge?: cdk.Duration;
+  readonly exposeHeaders?: string[];
+}
+
 export interface ControlPlaneAPIProps {
   readonly auth: IAuth;
   readonly disableAPILogging?: boolean;
+  readonly apiCorsConfig?: APICorsConfig;
 }
 
 export class ControlPlaneAPI extends Construct {
@@ -24,9 +33,7 @@ export class ControlPlaneAPI extends Construct {
     super(scope, id);
     addTemplateTag(this, 'ControlPlaneAPI');
     this.api = new apigatewayV2.HttpApi(this, 'controlPlaneAPI', {
-      corsPreflight: {
-        allowOrigins: apigateway.Cors.ALL_ORIGINS,
-      },
+      corsPreflight: props.apiCorsConfig,
     });
 
     if (props.disableAPILogging) {

--- a/src/control-plane/control-plane-api.ts
+++ b/src/control-plane/control-plane-api.ts
@@ -10,15 +10,6 @@ import { Construct } from 'constructs';
 import { IAuth } from './auth/auth-interface';
 import { addTemplateTag } from '../utils';
 
-export interface APICorsConfig {
-  readonly allowOrigins?: string[];
-  readonly allowCredentials?: boolean;
-  readonly allowHeaders?: string[];
-  readonly allowMethods?: apigatewayV2.CorsHttpMethod[];
-  readonly maxAge?: cdk.Duration;
-  readonly exposeHeaders?: string[];
-}
-
 export interface ControlPlaneAPIProps {
   readonly auth: IAuth;
   readonly disableAPILogging?: boolean;
@@ -26,7 +17,7 @@ export interface ControlPlaneAPIProps {
   /**
    * Settings for Cors Configuration for the ControlPlane API.
    */
-  readonly apiCorsConfig?: APICorsConfig;
+  readonly apiCorsConfig?: apigatewayV2.CorsPreflightOptions;
 }
 
 export class ControlPlaneAPI extends Construct {

--- a/src/control-plane/control-plane.ts
+++ b/src/control-plane/control-plane.ts
@@ -55,7 +55,7 @@ export interface ControlPlaneProps {
   readonly disableAPILogging?: boolean;
 
   /**
-   * Settings for the Cors Configuration for the ControlPlane API.
+   * Settings for Cors Configuration for the ControlPlane API.
    */
   readonly apiCorsConfig?: APICorsConfig;
 }

--- a/src/control-plane/control-plane.ts
+++ b/src/control-plane/control-plane.ts
@@ -7,12 +7,12 @@ import { Construct } from 'constructs';
 import { IAuth } from './auth/auth-interface';
 import { CognitoAuth } from './auth/cognito-auth';
 import { BillingProvider, IBilling } from './billing';
-import { ControlPlaneAPI } from './control-plane-api';
-import { TenantConfigService } from './tenant-config/tenant-config.service';
 import { TenantManagementService } from './tenant-management/tenant-management.service';
 import { UserManagementService } from './user-management/user-management.service';
+import { APICorsConfig, ControlPlaneAPI } from './control-plane-api';
 import { DestroyPolicySetter } from '../cdk-aspect/destroy-policy-setter';
 import { addTemplateTag, EventManager, IEventManager } from '../utils';
+import { TenantConfigService } from './tenant-config';
 
 export interface ControlPlaneProps {
   /**
@@ -53,6 +53,11 @@ export interface ControlPlaneProps {
    * @default false
    */
   readonly disableAPILogging?: boolean;
+
+  /**
+   * Settings for the Cors Configuration for the ControlPlane API.
+   */
+  readonly apiCorsConfig?: APICorsConfig;
 }
 
 export class ControlPlane extends Construct {
@@ -87,6 +92,7 @@ export class ControlPlane extends Construct {
     const api = new ControlPlaneAPI(this, 'controlPlaneApi', {
       auth,
       disableAPILogging: props.disableAPILogging,
+      apiCorsConfig: props.apiCorsConfig,
     });
 
     const eventManager = props.eventManager ?? new EventManager(this, 'EventManager');

--- a/src/control-plane/control-plane.ts
+++ b/src/control-plane/control-plane.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import * as cdk from 'aws-cdk-lib';
+import { CorsPreflightOptions } from 'aws-cdk-lib/aws-apigatewayv2';
 import { NagSuppressions } from 'cdk-nag';
 import { Construct } from 'constructs';
 import { IAuth } from './auth/auth-interface';
@@ -9,7 +10,7 @@ import { CognitoAuth } from './auth/cognito-auth';
 import { BillingProvider, IBilling } from './billing';
 import { TenantManagementService } from './tenant-management/tenant-management.service';
 import { UserManagementService } from './user-management/user-management.service';
-import { APICorsConfig, ControlPlaneAPI } from './control-plane-api';
+import { ControlPlaneAPI } from './control-plane-api';
 import { DestroyPolicySetter } from '../cdk-aspect/destroy-policy-setter';
 import { addTemplateTag, EventManager, IEventManager } from '../utils';
 import { TenantConfigService } from './tenant-config';
@@ -57,7 +58,7 @@ export interface ControlPlaneProps {
   /**
    * Settings for Cors Configuration for the ControlPlane API.
    */
-  readonly apiCorsConfig?: APICorsConfig;
+  readonly apiCorsConfig?: CorsPreflightOptions;
 }
 
 export class ControlPlane extends Construct {

--- a/src/control-plane/control-plane.ts
+++ b/src/control-plane/control-plane.ts
@@ -8,12 +8,12 @@ import { Construct } from 'constructs';
 import { IAuth } from './auth/auth-interface';
 import { CognitoAuth } from './auth/cognito-auth';
 import { BillingProvider, IBilling } from './billing';
+import { ControlPlaneAPI } from './control-plane-api';
+import { TenantConfigService } from './tenant-config';
 import { TenantManagementService } from './tenant-management/tenant-management.service';
 import { UserManagementService } from './user-management/user-management.service';
-import { ControlPlaneAPI } from './control-plane-api';
 import { DestroyPolicySetter } from '../cdk-aspect/destroy-policy-setter';
 import { addTemplateTag, EventManager, IEventManager } from '../utils';
-import { TenantConfigService } from './tenant-config';
 
 export interface ControlPlaneProps {
   /**


### PR DESCRIPTION
### Issue # (if applicable)

Closes #<issue number here>.

### Reason for this change

We should be able to set the CORS config for the control plane API. I am running into an issue when running the serverless ref arch and accessing the API (on a different domain) via the UI hosted on cloudfront.

### Description of changes

- Added (optional) parameters that can be passed into the control plane to set the cors config for the control plane API.
- Update Cognito UserPool domain name prefix so that it includes username.

### Description of how you validated changes

<!--Have you added any unit tests and/or integration tests?-->

### Checklist

- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/sbt-aws/blob/main/CONTRIBUTING.md)
- [x] I have updated the relevant documentation (if applicable).

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the project license.*
