### PR TITLE
fix: avoid stringifying json response

### DIFF
--- a/resources/functions/user-management/cognito_user_management_service.py
+++ b/resources/functions/user-management/cognito_user_management_service.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import boto3
-import json
 
 client = boto3.client('cognito-idp')
 
@@ -169,7 +168,7 @@ class UserInfo:
         self.modified = modified
 
     def serialize(self):
-        return json.dumps(self.__dict__, default=str)
+        return self.__dict__
 
 
 class UserInfoList:
@@ -181,4 +180,4 @@ class UserInfoList:
 
     def serialize(self):
         user_dicts = [user.__dict__ for user in self.users]
-        return json.dumps(user_dicts, default=str)
+        return user_dicts


### PR DESCRIPTION
### Issue # (if applicable)

Closes #70 

### Reason for this change

Stringifying the dict led to a stringified json object

### Description of changes

No longer stringifying the dict.

### Description of how you validated changes

Tested with serverless-ref-arch

### Checklist

- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/sbt-aws/blob/main/CONTRIBUTING.md)
- [x] I have updated the relevant documentation (if applicable).

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the project license.*
