### PR TITLE
refactor: Updated readme - removed the name property from JobRunnerProps

### DIFF
--- a/docs/public/README.md
+++ b/docs/public/README.md
@@ -203,7 +203,6 @@ Notice the use of the `provisioning.sh` and `deprovisioning.sh` scripts at the t
 
 ```typescript
 const provisioningJobRunnerProps = {
-  name: 'provisioning',
   permissions: PolicyDocument.fromJson(/*See below*/),
   script: '' /*See below*/,
   environmentStringVariablesFromIncomingEvent: ['tenantId', 'tier'],
@@ -223,7 +222,6 @@ Let's take a moment and dissect this object.
 
 | Key                                             | Type                                                                                                  | Purpose                                                                                                            |
 | ----------------------------------------------- | ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
-| **name**                                        | string                                                                                                | The **name** key is just a name for this job.                                                                      |
 | **script**                                      | string                                                                                                | A string in bash script format that represents the job to be run (example below)                                   |
 | **permissions**                                 | [PolicyDocument](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_iam.PolicyDocument.html) | An IAM policy document giving this job the IAM permisisons it needs to do what it's being asked to do              |
 | **environmentStringVariablesFromIncomingEvent** | string[]                                                                                              | The environment variables to import into the BashJobRunner from event details field.                               |
@@ -373,7 +371,6 @@ export class AppPlaneStack extends cdk.Stack {
     super(scope, id, props);
 
     const provisioningJobRunnerProps = {
-      name: 'provisioning',
       permissions: new PolicyDocument({
         statements: [
           new PolicyStatement({


### PR DESCRIPTION
### Issue # (if applicable)

Closes #<issue number here>.

### Reason for this change

This change allows JobRunners to be created independently outside of CoreAppPlane

### Description of changes

Updated the readme


### Checklist

- [ X] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/sbt-aws/blob/main/CONTRIBUTING.md)
- [ X] I have updated the relevant documentation (if applicable).

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the project license.*
