### PR TITLE
fix: lambda env key name fix

### DIFF
--- a/src/control-plane/aws-marketplace/saas-product.ts
+++ b/src/control-plane/aws-marketplace/saas-product.ts
@@ -377,7 +377,7 @@ exports.redirecthandler = async(event, context, callback) => {
 
     if (props.marketplaceSellerEmail) {
       registerNewMarketplaceCustomerPython.addEnvironment(
-        'MarketplaceSellerEmail',
+        'MARKETPLACE_SELLER_EMAIL',
         props.marketplaceSellerEmail
       );
     }


### PR DESCRIPTION
### Issue # (if applicable)

Closes #<issue number here>.

### Reason for this change

A key name of the environment variable for market place seller email is wrong on RegisterNewMarketplaceCustomerPython Lambda function.
It causes that lambda function never send an email to buyers.

### Description of changes

fix key name

### Description of how you validated changes

### Checklist

- [ ] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/sbt-aws/blob/main/CONTRIBUTING.md)
- [ ] I have updated the relevant documentation (if applicable).

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the project license.*
