### PR TITLE
refactor(core-app-plane)!: replace BashJobRunner with ScriptJob

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -143,6 +143,7 @@
     },
     {
       "name": "@aws-cdk/aws-lambda-python-alpha",
+      "version": "2.140.0-alpha.0",
       "type": "runtime"
     },
     {

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -34,7 +34,7 @@ const project = new awscdk.AwsCdkConstructLibrary({
   copyrightPeriod: '2024-',
   defaultReleaseBranch: 'main',
   deps: [
-    '@aws-cdk/aws-lambda-python-alpha',
+    `@aws-cdk/aws-lambda-python-alpha@${CDK_VERSION}-alpha.0`,
     'cdk-nag',
     `@aws-cdk/aws-kinesisfirehose-alpha@${CDK_VERSION}-alpha.0`,
     `@aws-cdk/aws-kinesisfirehose-destinations-alpha@${CDK_VERSION}-alpha.0`,

--- a/API.md
+++ b/API.md
@@ -1215,7 +1215,7 @@ The EventManager instance that allows connecting to events flowing between the C
 
 ### DeprovisioningScriptJob <a name="DeprovisioningScriptJob" id="@cdklabs/sbt-aws.DeprovisioningScriptJob"></a>
 
-Provides a ProvisioningScriptJob to execute arbitrary bash code.
+Provides a DeprovisioningScriptJob to execute arbitrary bash code.
 
 This is a simple wrapper around ScriptJob that reduces some of the parameters
 that need to be configured.

--- a/API.md
+++ b/API.md
@@ -151,172 +151,6 @@ when registering a new customer.
 ---
 
 
-### BashJobRunner <a name="BashJobRunner" id="@cdklabs/sbt-aws.BashJobRunner"></a>
-
-Provides a BashJobRunner to execute arbitrary bash code.
-
-#### Initializers <a name="Initializers" id="@cdklabs/sbt-aws.BashJobRunner.Initializer"></a>
-
-```typescript
-import { BashJobRunner } from '@cdklabs/sbt-aws'
-
-new BashJobRunner(scope: Construct, id: string, props: BashJobRunnerProps)
-```
-
-| **Name** | **Type** | **Description** |
-| --- | --- | --- |
-| <code><a href="#@cdklabs/sbt-aws.BashJobRunner.Initializer.parameter.scope">scope</a></code> | <code>constructs.Construct</code> | *No description.* |
-| <code><a href="#@cdklabs/sbt-aws.BashJobRunner.Initializer.parameter.id">id</a></code> | <code>string</code> | *No description.* |
-| <code><a href="#@cdklabs/sbt-aws.BashJobRunner.Initializer.parameter.props">props</a></code> | <code><a href="#@cdklabs/sbt-aws.BashJobRunnerProps">BashJobRunnerProps</a></code> | *No description.* |
-
----
-
-##### `scope`<sup>Required</sup> <a name="scope" id="@cdklabs/sbt-aws.BashJobRunner.Initializer.parameter.scope"></a>
-
-- *Type:* constructs.Construct
-
----
-
-##### `id`<sup>Required</sup> <a name="id" id="@cdklabs/sbt-aws.BashJobRunner.Initializer.parameter.id"></a>
-
-- *Type:* string
-
----
-
-##### `props`<sup>Required</sup> <a name="props" id="@cdklabs/sbt-aws.BashJobRunner.Initializer.parameter.props"></a>
-
-- *Type:* <a href="#@cdklabs/sbt-aws.BashJobRunnerProps">BashJobRunnerProps</a>
-
----
-
-#### Methods <a name="Methods" id="Methods"></a>
-
-| **Name** | **Description** |
-| --- | --- |
-| <code><a href="#@cdklabs/sbt-aws.BashJobRunner.toString">toString</a></code> | Returns a string representation of this construct. |
-
----
-
-##### `toString` <a name="toString" id="@cdklabs/sbt-aws.BashJobRunner.toString"></a>
-
-```typescript
-public toString(): string
-```
-
-Returns a string representation of this construct.
-
-#### Static Functions <a name="Static Functions" id="Static Functions"></a>
-
-| **Name** | **Description** |
-| --- | --- |
-| <code><a href="#@cdklabs/sbt-aws.BashJobRunner.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
-
----
-
-##### ~~`isConstruct`~~ <a name="isConstruct" id="@cdklabs/sbt-aws.BashJobRunner.isConstruct"></a>
-
-```typescript
-import { BashJobRunner } from '@cdklabs/sbt-aws'
-
-BashJobRunner.isConstruct(x: any)
-```
-
-Checks if `x` is a construct.
-
-###### `x`<sup>Required</sup> <a name="x" id="@cdklabs/sbt-aws.BashJobRunner.isConstruct.parameter.x"></a>
-
-- *Type:* any
-
-Any object.
-
----
-
-#### Properties <a name="Properties" id="Properties"></a>
-
-| **Name** | **Type** | **Description** |
-| --- | --- | --- |
-| <code><a href="#@cdklabs/sbt-aws.BashJobRunner.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
-| <code><a href="#@cdklabs/sbt-aws.BashJobRunner.property.codebuildProject">codebuildProject</a></code> | <code>aws-cdk-lib.aws_codebuild.Project</code> | The codebuildProject used to implement this BashJobRunner. |
-| <code><a href="#@cdklabs/sbt-aws.BashJobRunner.property.eventTarget">eventTarget</a></code> | <code>aws-cdk-lib.aws_events.IRuleTarget</code> | The eventTarget to use when triggering this BashJobRunner. |
-| <code><a href="#@cdklabs/sbt-aws.BashJobRunner.property.incomingEvent">incomingEvent</a></code> | <code><a href="#@cdklabs/sbt-aws.DetailType">DetailType</a></code> | The incoming event DetailType that triggers this job. |
-| <code><a href="#@cdklabs/sbt-aws.BashJobRunner.property.provisioningStateMachine">provisioningStateMachine</a></code> | <code>aws-cdk-lib.aws_stepfunctions.StateMachine</code> | The StateMachine used to implement this BashJobRunner orchestration. |
-| <code><a href="#@cdklabs/sbt-aws.BashJobRunner.property.environmentVariablesToOutgoingEvent">environmentVariablesToOutgoingEvent</a></code> | <code>string[]</code> | The environment variables to export into the outgoing event once the BashJobRunner has finished. |
-
----
-
-##### `node`<sup>Required</sup> <a name="node" id="@cdklabs/sbt-aws.BashJobRunner.property.node"></a>
-
-```typescript
-public readonly node: Node;
-```
-
-- *Type:* constructs.Node
-
-The tree node.
-
----
-
-##### `codebuildProject`<sup>Required</sup> <a name="codebuildProject" id="@cdklabs/sbt-aws.BashJobRunner.property.codebuildProject"></a>
-
-```typescript
-public readonly codebuildProject: Project;
-```
-
-- *Type:* aws-cdk-lib.aws_codebuild.Project
-
-The codebuildProject used to implement this BashJobRunner.
-
----
-
-##### `eventTarget`<sup>Required</sup> <a name="eventTarget" id="@cdklabs/sbt-aws.BashJobRunner.property.eventTarget"></a>
-
-```typescript
-public readonly eventTarget: IRuleTarget;
-```
-
-- *Type:* aws-cdk-lib.aws_events.IRuleTarget
-
-The eventTarget to use when triggering this BashJobRunner.
-
----
-
-##### `incomingEvent`<sup>Required</sup> <a name="incomingEvent" id="@cdklabs/sbt-aws.BashJobRunner.property.incomingEvent"></a>
-
-```typescript
-public readonly incomingEvent: DetailType;
-```
-
-- *Type:* <a href="#@cdklabs/sbt-aws.DetailType">DetailType</a>
-
-The incoming event DetailType that triggers this job.
-
----
-
-##### `provisioningStateMachine`<sup>Required</sup> <a name="provisioningStateMachine" id="@cdklabs/sbt-aws.BashJobRunner.property.provisioningStateMachine"></a>
-
-```typescript
-public readonly provisioningStateMachine: StateMachine;
-```
-
-- *Type:* aws-cdk-lib.aws_stepfunctions.StateMachine
-
-The StateMachine used to implement this BashJobRunner orchestration.
-
----
-
-##### `environmentVariablesToOutgoingEvent`<sup>Optional</sup> <a name="environmentVariablesToOutgoingEvent" id="@cdklabs/sbt-aws.BashJobRunner.property.environmentVariablesToOutgoingEvent"></a>
-
-```typescript
-public readonly environmentVariablesToOutgoingEvent: string[];
-```
-
-- *Type:* string[]
-
-The environment variables to export into the outgoing event once the BashJobRunner has finished.
-
----
-
-
 ### BillingProvider <a name="BillingProvider" id="@cdklabs/sbt-aws.BillingProvider"></a>
 
 Represents a Billing Provider that handles billing-related operations.
@@ -1379,6 +1213,175 @@ The EventManager instance that allows connecting to events flowing between the C
 ---
 
 
+### DeprovisioningScriptJob <a name="DeprovisioningScriptJob" id="@cdklabs/sbt-aws.DeprovisioningScriptJob"></a>
+
+Provides a ProvisioningScriptJob to execute arbitrary bash code.
+
+This is a simple wrapper around ScriptJob that reduces some of the parameters
+that need to be configured.
+
+#### Initializers <a name="Initializers" id="@cdklabs/sbt-aws.DeprovisioningScriptJob.Initializer"></a>
+
+```typescript
+import { DeprovisioningScriptJob } from '@cdklabs/sbt-aws'
+
+new DeprovisioningScriptJob(scope: Construct, id: string, props: TenantLifecycleScriptJobProps)
+```
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@cdklabs/sbt-aws.DeprovisioningScriptJob.Initializer.parameter.scope">scope</a></code> | <code>constructs.Construct</code> | *No description.* |
+| <code><a href="#@cdklabs/sbt-aws.DeprovisioningScriptJob.Initializer.parameter.id">id</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#@cdklabs/sbt-aws.DeprovisioningScriptJob.Initializer.parameter.props">props</a></code> | <code><a href="#@cdklabs/sbt-aws.TenantLifecycleScriptJobProps">TenantLifecycleScriptJobProps</a></code> | *No description.* |
+
+---
+
+##### `scope`<sup>Required</sup> <a name="scope" id="@cdklabs/sbt-aws.DeprovisioningScriptJob.Initializer.parameter.scope"></a>
+
+- *Type:* constructs.Construct
+
+---
+
+##### `id`<sup>Required</sup> <a name="id" id="@cdklabs/sbt-aws.DeprovisioningScriptJob.Initializer.parameter.id"></a>
+
+- *Type:* string
+
+---
+
+##### `props`<sup>Required</sup> <a name="props" id="@cdklabs/sbt-aws.DeprovisioningScriptJob.Initializer.parameter.props"></a>
+
+- *Type:* <a href="#@cdklabs/sbt-aws.TenantLifecycleScriptJobProps">TenantLifecycleScriptJobProps</a>
+
+---
+
+#### Methods <a name="Methods" id="Methods"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#@cdklabs/sbt-aws.DeprovisioningScriptJob.toString">toString</a></code> | Returns a string representation of this construct. |
+
+---
+
+##### `toString` <a name="toString" id="@cdklabs/sbt-aws.DeprovisioningScriptJob.toString"></a>
+
+```typescript
+public toString(): string
+```
+
+Returns a string representation of this construct.
+
+#### Static Functions <a name="Static Functions" id="Static Functions"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#@cdklabs/sbt-aws.DeprovisioningScriptJob.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
+
+---
+
+##### ~~`isConstruct`~~ <a name="isConstruct" id="@cdklabs/sbt-aws.DeprovisioningScriptJob.isConstruct"></a>
+
+```typescript
+import { DeprovisioningScriptJob } from '@cdklabs/sbt-aws'
+
+DeprovisioningScriptJob.isConstruct(x: any)
+```
+
+Checks if `x` is a construct.
+
+###### `x`<sup>Required</sup> <a name="x" id="@cdklabs/sbt-aws.DeprovisioningScriptJob.isConstruct.parameter.x"></a>
+
+- *Type:* any
+
+Any object.
+
+---
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@cdklabs/sbt-aws.DeprovisioningScriptJob.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
+| <code><a href="#@cdklabs/sbt-aws.DeprovisioningScriptJob.property.codebuildProject">codebuildProject</a></code> | <code>aws-cdk-lib.aws_codebuild.Project</code> | The codebuildProject used to implement this ScriptJob. |
+| <code><a href="#@cdklabs/sbt-aws.DeprovisioningScriptJob.property.eventTarget">eventTarget</a></code> | <code>aws-cdk-lib.aws_events.IRuleTarget</code> | The eventTarget to use when triggering this ScriptJob. |
+| <code><a href="#@cdklabs/sbt-aws.DeprovisioningScriptJob.property.incomingEvent">incomingEvent</a></code> | <code><a href="#@cdklabs/sbt-aws.DetailType">DetailType</a></code> | The incoming event DetailType that triggers this job. |
+| <code><a href="#@cdklabs/sbt-aws.DeprovisioningScriptJob.property.provisioningStateMachine">provisioningStateMachine</a></code> | <code>aws-cdk-lib.aws_stepfunctions.StateMachine</code> | The StateMachine used to implement this ScriptJob orchestration. |
+| <code><a href="#@cdklabs/sbt-aws.DeprovisioningScriptJob.property.environmentVariablesToOutgoingEvent">environmentVariablesToOutgoingEvent</a></code> | <code>string[]</code> | The environment variables to export into the outgoing event once the ScriptJob has finished. |
+
+---
+
+##### `node`<sup>Required</sup> <a name="node" id="@cdklabs/sbt-aws.DeprovisioningScriptJob.property.node"></a>
+
+```typescript
+public readonly node: Node;
+```
+
+- *Type:* constructs.Node
+
+The tree node.
+
+---
+
+##### `codebuildProject`<sup>Required</sup> <a name="codebuildProject" id="@cdklabs/sbt-aws.DeprovisioningScriptJob.property.codebuildProject"></a>
+
+```typescript
+public readonly codebuildProject: Project;
+```
+
+- *Type:* aws-cdk-lib.aws_codebuild.Project
+
+The codebuildProject used to implement this ScriptJob.
+
+---
+
+##### `eventTarget`<sup>Required</sup> <a name="eventTarget" id="@cdklabs/sbt-aws.DeprovisioningScriptJob.property.eventTarget"></a>
+
+```typescript
+public readonly eventTarget: IRuleTarget;
+```
+
+- *Type:* aws-cdk-lib.aws_events.IRuleTarget
+
+The eventTarget to use when triggering this ScriptJob.
+
+---
+
+##### `incomingEvent`<sup>Required</sup> <a name="incomingEvent" id="@cdklabs/sbt-aws.DeprovisioningScriptJob.property.incomingEvent"></a>
+
+```typescript
+public readonly incomingEvent: DetailType;
+```
+
+- *Type:* <a href="#@cdklabs/sbt-aws.DetailType">DetailType</a>
+
+The incoming event DetailType that triggers this job.
+
+---
+
+##### `provisioningStateMachine`<sup>Required</sup> <a name="provisioningStateMachine" id="@cdklabs/sbt-aws.DeprovisioningScriptJob.property.provisioningStateMachine"></a>
+
+```typescript
+public readonly provisioningStateMachine: StateMachine;
+```
+
+- *Type:* aws-cdk-lib.aws_stepfunctions.StateMachine
+
+The StateMachine used to implement this ScriptJob orchestration.
+
+---
+
+##### `environmentVariablesToOutgoingEvent`<sup>Optional</sup> <a name="environmentVariablesToOutgoingEvent" id="@cdklabs/sbt-aws.DeprovisioningScriptJob.property.environmentVariablesToOutgoingEvent"></a>
+
+```typescript
+public readonly environmentVariablesToOutgoingEvent: string[];
+```
+
+- *Type:* string[]
+
+The environment variables to export into the outgoing event once the ScriptJob has finished.
+
+---
+
+
 ### EventManager <a name="EventManager" id="@cdklabs/sbt-aws.EventManager"></a>
 
 - *Implements:* <a href="#@cdklabs/sbt-aws.IEventManager">IEventManager</a>
@@ -1770,6 +1773,175 @@ The DynamoDB table containing the aggregated data.
 ---
 
 
+### ProvisioningScriptJob <a name="ProvisioningScriptJob" id="@cdklabs/sbt-aws.ProvisioningScriptJob"></a>
+
+Provides a ProvisioningScriptJob to execute arbitrary bash code.
+
+This is a simple wrapper around ScriptJob that reduces some of the parameters
+that need to be configured.
+
+#### Initializers <a name="Initializers" id="@cdklabs/sbt-aws.ProvisioningScriptJob.Initializer"></a>
+
+```typescript
+import { ProvisioningScriptJob } from '@cdklabs/sbt-aws'
+
+new ProvisioningScriptJob(scope: Construct, id: string, props: TenantLifecycleScriptJobProps)
+```
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@cdklabs/sbt-aws.ProvisioningScriptJob.Initializer.parameter.scope">scope</a></code> | <code>constructs.Construct</code> | *No description.* |
+| <code><a href="#@cdklabs/sbt-aws.ProvisioningScriptJob.Initializer.parameter.id">id</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#@cdklabs/sbt-aws.ProvisioningScriptJob.Initializer.parameter.props">props</a></code> | <code><a href="#@cdklabs/sbt-aws.TenantLifecycleScriptJobProps">TenantLifecycleScriptJobProps</a></code> | *No description.* |
+
+---
+
+##### `scope`<sup>Required</sup> <a name="scope" id="@cdklabs/sbt-aws.ProvisioningScriptJob.Initializer.parameter.scope"></a>
+
+- *Type:* constructs.Construct
+
+---
+
+##### `id`<sup>Required</sup> <a name="id" id="@cdklabs/sbt-aws.ProvisioningScriptJob.Initializer.parameter.id"></a>
+
+- *Type:* string
+
+---
+
+##### `props`<sup>Required</sup> <a name="props" id="@cdklabs/sbt-aws.ProvisioningScriptJob.Initializer.parameter.props"></a>
+
+- *Type:* <a href="#@cdklabs/sbt-aws.TenantLifecycleScriptJobProps">TenantLifecycleScriptJobProps</a>
+
+---
+
+#### Methods <a name="Methods" id="Methods"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#@cdklabs/sbt-aws.ProvisioningScriptJob.toString">toString</a></code> | Returns a string representation of this construct. |
+
+---
+
+##### `toString` <a name="toString" id="@cdklabs/sbt-aws.ProvisioningScriptJob.toString"></a>
+
+```typescript
+public toString(): string
+```
+
+Returns a string representation of this construct.
+
+#### Static Functions <a name="Static Functions" id="Static Functions"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#@cdklabs/sbt-aws.ProvisioningScriptJob.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
+
+---
+
+##### ~~`isConstruct`~~ <a name="isConstruct" id="@cdklabs/sbt-aws.ProvisioningScriptJob.isConstruct"></a>
+
+```typescript
+import { ProvisioningScriptJob } from '@cdklabs/sbt-aws'
+
+ProvisioningScriptJob.isConstruct(x: any)
+```
+
+Checks if `x` is a construct.
+
+###### `x`<sup>Required</sup> <a name="x" id="@cdklabs/sbt-aws.ProvisioningScriptJob.isConstruct.parameter.x"></a>
+
+- *Type:* any
+
+Any object.
+
+---
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@cdklabs/sbt-aws.ProvisioningScriptJob.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
+| <code><a href="#@cdklabs/sbt-aws.ProvisioningScriptJob.property.codebuildProject">codebuildProject</a></code> | <code>aws-cdk-lib.aws_codebuild.Project</code> | The codebuildProject used to implement this ScriptJob. |
+| <code><a href="#@cdklabs/sbt-aws.ProvisioningScriptJob.property.eventTarget">eventTarget</a></code> | <code>aws-cdk-lib.aws_events.IRuleTarget</code> | The eventTarget to use when triggering this ScriptJob. |
+| <code><a href="#@cdklabs/sbt-aws.ProvisioningScriptJob.property.incomingEvent">incomingEvent</a></code> | <code><a href="#@cdklabs/sbt-aws.DetailType">DetailType</a></code> | The incoming event DetailType that triggers this job. |
+| <code><a href="#@cdklabs/sbt-aws.ProvisioningScriptJob.property.provisioningStateMachine">provisioningStateMachine</a></code> | <code>aws-cdk-lib.aws_stepfunctions.StateMachine</code> | The StateMachine used to implement this ScriptJob orchestration. |
+| <code><a href="#@cdklabs/sbt-aws.ProvisioningScriptJob.property.environmentVariablesToOutgoingEvent">environmentVariablesToOutgoingEvent</a></code> | <code>string[]</code> | The environment variables to export into the outgoing event once the ScriptJob has finished. |
+
+---
+
+##### `node`<sup>Required</sup> <a name="node" id="@cdklabs/sbt-aws.ProvisioningScriptJob.property.node"></a>
+
+```typescript
+public readonly node: Node;
+```
+
+- *Type:* constructs.Node
+
+The tree node.
+
+---
+
+##### `codebuildProject`<sup>Required</sup> <a name="codebuildProject" id="@cdklabs/sbt-aws.ProvisioningScriptJob.property.codebuildProject"></a>
+
+```typescript
+public readonly codebuildProject: Project;
+```
+
+- *Type:* aws-cdk-lib.aws_codebuild.Project
+
+The codebuildProject used to implement this ScriptJob.
+
+---
+
+##### `eventTarget`<sup>Required</sup> <a name="eventTarget" id="@cdklabs/sbt-aws.ProvisioningScriptJob.property.eventTarget"></a>
+
+```typescript
+public readonly eventTarget: IRuleTarget;
+```
+
+- *Type:* aws-cdk-lib.aws_events.IRuleTarget
+
+The eventTarget to use when triggering this ScriptJob.
+
+---
+
+##### `incomingEvent`<sup>Required</sup> <a name="incomingEvent" id="@cdklabs/sbt-aws.ProvisioningScriptJob.property.incomingEvent"></a>
+
+```typescript
+public readonly incomingEvent: DetailType;
+```
+
+- *Type:* <a href="#@cdklabs/sbt-aws.DetailType">DetailType</a>
+
+The incoming event DetailType that triggers this job.
+
+---
+
+##### `provisioningStateMachine`<sup>Required</sup> <a name="provisioningStateMachine" id="@cdklabs/sbt-aws.ProvisioningScriptJob.property.provisioningStateMachine"></a>
+
+```typescript
+public readonly provisioningStateMachine: StateMachine;
+```
+
+- *Type:* aws-cdk-lib.aws_stepfunctions.StateMachine
+
+The StateMachine used to implement this ScriptJob orchestration.
+
+---
+
+##### `environmentVariablesToOutgoingEvent`<sup>Optional</sup> <a name="environmentVariablesToOutgoingEvent" id="@cdklabs/sbt-aws.ProvisioningScriptJob.property.environmentVariablesToOutgoingEvent"></a>
+
+```typescript
+public readonly environmentVariablesToOutgoingEvent: string[];
+```
+
+- *Type:* string[]
+
+The environment variables to export into the outgoing event once the ScriptJob has finished.
+
+---
+
+
 ### SampleRegistrationWebPage <a name="SampleRegistrationWebPage" id="@cdklabs/sbt-aws.SampleRegistrationWebPage"></a>
 
 Constructs a sample registration web page hosted on Amazon S3 and fronted by Amazon CloudFront.
@@ -1869,6 +2041,172 @@ public readonly node: Node;
 - *Type:* constructs.Node
 
 The tree node.
+
+---
+
+
+### ScriptJob <a name="ScriptJob" id="@cdklabs/sbt-aws.ScriptJob"></a>
+
+Provides a ScriptJob to execute arbitrary bash code.
+
+#### Initializers <a name="Initializers" id="@cdklabs/sbt-aws.ScriptJob.Initializer"></a>
+
+```typescript
+import { ScriptJob } from '@cdklabs/sbt-aws'
+
+new ScriptJob(scope: Construct, id: string, props: ScriptJobProps)
+```
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@cdklabs/sbt-aws.ScriptJob.Initializer.parameter.scope">scope</a></code> | <code>constructs.Construct</code> | *No description.* |
+| <code><a href="#@cdklabs/sbt-aws.ScriptJob.Initializer.parameter.id">id</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#@cdklabs/sbt-aws.ScriptJob.Initializer.parameter.props">props</a></code> | <code><a href="#@cdklabs/sbt-aws.ScriptJobProps">ScriptJobProps</a></code> | *No description.* |
+
+---
+
+##### `scope`<sup>Required</sup> <a name="scope" id="@cdklabs/sbt-aws.ScriptJob.Initializer.parameter.scope"></a>
+
+- *Type:* constructs.Construct
+
+---
+
+##### `id`<sup>Required</sup> <a name="id" id="@cdklabs/sbt-aws.ScriptJob.Initializer.parameter.id"></a>
+
+- *Type:* string
+
+---
+
+##### `props`<sup>Required</sup> <a name="props" id="@cdklabs/sbt-aws.ScriptJob.Initializer.parameter.props"></a>
+
+- *Type:* <a href="#@cdklabs/sbt-aws.ScriptJobProps">ScriptJobProps</a>
+
+---
+
+#### Methods <a name="Methods" id="Methods"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#@cdklabs/sbt-aws.ScriptJob.toString">toString</a></code> | Returns a string representation of this construct. |
+
+---
+
+##### `toString` <a name="toString" id="@cdklabs/sbt-aws.ScriptJob.toString"></a>
+
+```typescript
+public toString(): string
+```
+
+Returns a string representation of this construct.
+
+#### Static Functions <a name="Static Functions" id="Static Functions"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#@cdklabs/sbt-aws.ScriptJob.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
+
+---
+
+##### ~~`isConstruct`~~ <a name="isConstruct" id="@cdklabs/sbt-aws.ScriptJob.isConstruct"></a>
+
+```typescript
+import { ScriptJob } from '@cdklabs/sbt-aws'
+
+ScriptJob.isConstruct(x: any)
+```
+
+Checks if `x` is a construct.
+
+###### `x`<sup>Required</sup> <a name="x" id="@cdklabs/sbt-aws.ScriptJob.isConstruct.parameter.x"></a>
+
+- *Type:* any
+
+Any object.
+
+---
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@cdklabs/sbt-aws.ScriptJob.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
+| <code><a href="#@cdklabs/sbt-aws.ScriptJob.property.codebuildProject">codebuildProject</a></code> | <code>aws-cdk-lib.aws_codebuild.Project</code> | The codebuildProject used to implement this ScriptJob. |
+| <code><a href="#@cdklabs/sbt-aws.ScriptJob.property.eventTarget">eventTarget</a></code> | <code>aws-cdk-lib.aws_events.IRuleTarget</code> | The eventTarget to use when triggering this ScriptJob. |
+| <code><a href="#@cdklabs/sbt-aws.ScriptJob.property.incomingEvent">incomingEvent</a></code> | <code><a href="#@cdklabs/sbt-aws.DetailType">DetailType</a></code> | The incoming event DetailType that triggers this job. |
+| <code><a href="#@cdklabs/sbt-aws.ScriptJob.property.provisioningStateMachine">provisioningStateMachine</a></code> | <code>aws-cdk-lib.aws_stepfunctions.StateMachine</code> | The StateMachine used to implement this ScriptJob orchestration. |
+| <code><a href="#@cdklabs/sbt-aws.ScriptJob.property.environmentVariablesToOutgoingEvent">environmentVariablesToOutgoingEvent</a></code> | <code>string[]</code> | The environment variables to export into the outgoing event once the ScriptJob has finished. |
+
+---
+
+##### `node`<sup>Required</sup> <a name="node" id="@cdklabs/sbt-aws.ScriptJob.property.node"></a>
+
+```typescript
+public readonly node: Node;
+```
+
+- *Type:* constructs.Node
+
+The tree node.
+
+---
+
+##### `codebuildProject`<sup>Required</sup> <a name="codebuildProject" id="@cdklabs/sbt-aws.ScriptJob.property.codebuildProject"></a>
+
+```typescript
+public readonly codebuildProject: Project;
+```
+
+- *Type:* aws-cdk-lib.aws_codebuild.Project
+
+The codebuildProject used to implement this ScriptJob.
+
+---
+
+##### `eventTarget`<sup>Required</sup> <a name="eventTarget" id="@cdklabs/sbt-aws.ScriptJob.property.eventTarget"></a>
+
+```typescript
+public readonly eventTarget: IRuleTarget;
+```
+
+- *Type:* aws-cdk-lib.aws_events.IRuleTarget
+
+The eventTarget to use when triggering this ScriptJob.
+
+---
+
+##### `incomingEvent`<sup>Required</sup> <a name="incomingEvent" id="@cdklabs/sbt-aws.ScriptJob.property.incomingEvent"></a>
+
+```typescript
+public readonly incomingEvent: DetailType;
+```
+
+- *Type:* <a href="#@cdklabs/sbt-aws.DetailType">DetailType</a>
+
+The incoming event DetailType that triggers this job.
+
+---
+
+##### `provisioningStateMachine`<sup>Required</sup> <a name="provisioningStateMachine" id="@cdklabs/sbt-aws.ScriptJob.property.provisioningStateMachine"></a>
+
+```typescript
+public readonly provisioningStateMachine: StateMachine;
+```
+
+- *Type:* aws-cdk-lib.aws_stepfunctions.StateMachine
+
+The StateMachine used to implement this ScriptJob orchestration.
+
+---
+
+##### `environmentVariablesToOutgoingEvent`<sup>Optional</sup> <a name="environmentVariablesToOutgoingEvent" id="@cdklabs/sbt-aws.ScriptJob.property.environmentVariablesToOutgoingEvent"></a>
+
+```typescript
+public readonly environmentVariablesToOutgoingEvent: string[];
+```
+
+- *Type:* string[]
+
+The environment variables to export into the outgoing event once the ScriptJob has finished.
 
 ---
 
@@ -2743,174 +3081,6 @@ fields is checked when a new customer is registered.
 
 ---
 
-### BashJobRunnerProps <a name="BashJobRunnerProps" id="@cdklabs/sbt-aws.BashJobRunnerProps"></a>
-
-Encapsulates the list of properties for a BashJobRunner.
-
-#### Initializer <a name="Initializer" id="@cdklabs/sbt-aws.BashJobRunnerProps.Initializer"></a>
-
-```typescript
-import { BashJobRunnerProps } from '@cdklabs/sbt-aws'
-
-const bashJobRunnerProps: BashJobRunnerProps = { ... }
-```
-
-#### Properties <a name="Properties" id="Properties"></a>
-
-| **Name** | **Type** | **Description** |
-| --- | --- | --- |
-| <code><a href="#@cdklabs/sbt-aws.BashJobRunnerProps.property.eventManager">eventManager</a></code> | <code><a href="#@cdklabs/sbt-aws.IEventManager">IEventManager</a></code> | The EventManager instance that allows connecting to events flowing between the Control Plane and other components. |
-| <code><a href="#@cdklabs/sbt-aws.BashJobRunnerProps.property.incomingEvent">incomingEvent</a></code> | <code><a href="#@cdklabs/sbt-aws.DetailType">DetailType</a></code> | The incoming event DetailType that triggers this job. |
-| <code><a href="#@cdklabs/sbt-aws.BashJobRunnerProps.property.outgoingEvent">outgoingEvent</a></code> | <code><a href="#@cdklabs/sbt-aws.DetailType">DetailType</a></code> | The outgoing event DetailType that is emitted upon job completion. |
-| <code><a href="#@cdklabs/sbt-aws.BashJobRunnerProps.property.permissions">permissions</a></code> | <code>aws-cdk-lib.aws_iam.PolicyDocument</code> | The IAM permission document for the BashJobRunner. |
-| <code><a href="#@cdklabs/sbt-aws.BashJobRunnerProps.property.script">script</a></code> | <code>string</code> | The bash script to run as part of the BashJobRunner. |
-| <code><a href="#@cdklabs/sbt-aws.BashJobRunnerProps.property.environmentJSONVariablesFromIncomingEvent">environmentJSONVariablesFromIncomingEvent</a></code> | <code>string[]</code> | The environment variables to import into the BashJobRunner from event details field. |
-| <code><a href="#@cdklabs/sbt-aws.BashJobRunnerProps.property.environmentStringVariablesFromIncomingEvent">environmentStringVariablesFromIncomingEvent</a></code> | <code>string[]</code> | The environment variables to import into the BashJobRunner from event details field. |
-| <code><a href="#@cdklabs/sbt-aws.BashJobRunnerProps.property.environmentVariablesToOutgoingEvent">environmentVariablesToOutgoingEvent</a></code> | <code>string[]</code> | The environment variables to export into the outgoing event once the BashJobRunner has finished. |
-| <code><a href="#@cdklabs/sbt-aws.BashJobRunnerProps.property.postScript">postScript</a></code> | <code>string</code> | The bash script to run after the main script has completed. |
-| <code><a href="#@cdklabs/sbt-aws.BashJobRunnerProps.property.scriptEnvironmentVariables">scriptEnvironmentVariables</a></code> | <code>{[ key: string ]: string}</code> | The variables to pass into the codebuild BashJobRunner. |
-| <code><a href="#@cdklabs/sbt-aws.BashJobRunnerProps.property.tenantIdentifierKeyInIncomingEvent">tenantIdentifierKeyInIncomingEvent</a></code> | <code>string</code> | The key where the tenant identifier is to be extracted from in the incoming event. |
-
----
-
-##### `eventManager`<sup>Required</sup> <a name="eventManager" id="@cdklabs/sbt-aws.BashJobRunnerProps.property.eventManager"></a>
-
-```typescript
-public readonly eventManager: IEventManager;
-```
-
-- *Type:* <a href="#@cdklabs/sbt-aws.IEventManager">IEventManager</a>
-
-The EventManager instance that allows connecting to events flowing between the Control Plane and other components.
-
----
-
-##### `incomingEvent`<sup>Required</sup> <a name="incomingEvent" id="@cdklabs/sbt-aws.BashJobRunnerProps.property.incomingEvent"></a>
-
-```typescript
-public readonly incomingEvent: DetailType;
-```
-
-- *Type:* <a href="#@cdklabs/sbt-aws.DetailType">DetailType</a>
-
-The incoming event DetailType that triggers this job.
-
----
-
-##### `outgoingEvent`<sup>Required</sup> <a name="outgoingEvent" id="@cdklabs/sbt-aws.BashJobRunnerProps.property.outgoingEvent"></a>
-
-```typescript
-public readonly outgoingEvent: DetailType;
-```
-
-- *Type:* <a href="#@cdklabs/sbt-aws.DetailType">DetailType</a>
-
-The outgoing event DetailType that is emitted upon job completion.
-
----
-
-##### `permissions`<sup>Required</sup> <a name="permissions" id="@cdklabs/sbt-aws.BashJobRunnerProps.property.permissions"></a>
-
-```typescript
-public readonly permissions: PolicyDocument;
-```
-
-- *Type:* aws-cdk-lib.aws_iam.PolicyDocument
-
-The IAM permission document for the BashJobRunner.
-
----
-
-##### `script`<sup>Required</sup> <a name="script" id="@cdklabs/sbt-aws.BashJobRunnerProps.property.script"></a>
-
-```typescript
-public readonly script: string;
-```
-
-- *Type:* string
-
-The bash script to run as part of the BashJobRunner.
-
----
-
-##### `environmentJSONVariablesFromIncomingEvent`<sup>Optional</sup> <a name="environmentJSONVariablesFromIncomingEvent" id="@cdklabs/sbt-aws.BashJobRunnerProps.property.environmentJSONVariablesFromIncomingEvent"></a>
-
-```typescript
-public readonly environmentJSONVariablesFromIncomingEvent: string[];
-```
-
-- *Type:* string[]
-
-The environment variables to import into the BashJobRunner from event details field.
-
-This argument consists of the names of only JSON-formatted string type variables.
-Ex. '{"test": 2}'
-
----
-
-##### `environmentStringVariablesFromIncomingEvent`<sup>Optional</sup> <a name="environmentStringVariablesFromIncomingEvent" id="@cdklabs/sbt-aws.BashJobRunnerProps.property.environmentStringVariablesFromIncomingEvent"></a>
-
-```typescript
-public readonly environmentStringVariablesFromIncomingEvent: string[];
-```
-
-- *Type:* string[]
-
-The environment variables to import into the BashJobRunner from event details field.
-
-This argument consists of the names of only string type variables. Ex. 'test'
-
----
-
-##### `environmentVariablesToOutgoingEvent`<sup>Optional</sup> <a name="environmentVariablesToOutgoingEvent" id="@cdklabs/sbt-aws.BashJobRunnerProps.property.environmentVariablesToOutgoingEvent"></a>
-
-```typescript
-public readonly environmentVariablesToOutgoingEvent: string[];
-```
-
-- *Type:* string[]
-
-The environment variables to export into the outgoing event once the BashJobRunner has finished.
-
----
-
-##### `postScript`<sup>Optional</sup> <a name="postScript" id="@cdklabs/sbt-aws.BashJobRunnerProps.property.postScript"></a>
-
-```typescript
-public readonly postScript: string;
-```
-
-- *Type:* string
-
-The bash script to run after the main script has completed.
-
----
-
-##### `scriptEnvironmentVariables`<sup>Optional</sup> <a name="scriptEnvironmentVariables" id="@cdklabs/sbt-aws.BashJobRunnerProps.property.scriptEnvironmentVariables"></a>
-
-```typescript
-public readonly scriptEnvironmentVariables: {[ key: string ]: string};
-```
-
-- *Type:* {[ key: string ]: string}
-
-The variables to pass into the codebuild BashJobRunner.
-
----
-
-##### `tenantIdentifierKeyInIncomingEvent`<sup>Optional</sup> <a name="tenantIdentifierKeyInIncomingEvent" id="@cdklabs/sbt-aws.BashJobRunnerProps.property.tenantIdentifierKeyInIncomingEvent"></a>
-
-```typescript
-public readonly tenantIdentifierKeyInIncomingEvent: string;
-```
-
-- *Type:* string
-- *Default:* 'tenantId'
-
-The key where the tenant identifier is to be extracted from in the incoming event.
-
----
-
 ### BillingProviderProps <a name="BillingProviderProps" id="@cdklabs/sbt-aws.BillingProviderProps"></a>
 
 Encapsulates the list of properties for a BillingProvider.
@@ -3215,7 +3385,7 @@ const coreApplicationPlaneProps: CoreApplicationPlaneProps = { ... }
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
 | <code><a href="#@cdklabs/sbt-aws.CoreApplicationPlaneProps.property.eventManager">eventManager</a></code> | <code><a href="#@cdklabs/sbt-aws.IEventManager">IEventManager</a></code> | *No description.* |
-| <code><a href="#@cdklabs/sbt-aws.CoreApplicationPlaneProps.property.jobRunnersList">jobRunnersList</a></code> | <code><a href="#@cdklabs/sbt-aws.BashJobRunner">BashJobRunner</a>[]</code> | The list of JobRunners. |
+| <code><a href="#@cdklabs/sbt-aws.CoreApplicationPlaneProps.property.scriptJobs">scriptJobs</a></code> | <code><a href="#@cdklabs/sbt-aws.ScriptJob">ScriptJob</a>[]</code> | The list of JobRunners. |
 
 ---
 
@@ -3229,13 +3399,13 @@ public readonly eventManager: IEventManager;
 
 ---
 
-##### `jobRunnersList`<sup>Optional</sup> <a name="jobRunnersList" id="@cdklabs/sbt-aws.CoreApplicationPlaneProps.property.jobRunnersList"></a>
+##### `scriptJobs`<sup>Optional</sup> <a name="scriptJobs" id="@cdklabs/sbt-aws.CoreApplicationPlaneProps.property.scriptJobs"></a>
 
 ```typescript
-public readonly jobRunnersList: BashJobRunner[];
+public readonly scriptJobs: ScriptJob[];
 ```
 
-- *Type:* <a href="#@cdklabs/sbt-aws.BashJobRunner">BashJobRunner</a>[]
+- *Type:* <a href="#@cdklabs/sbt-aws.ScriptJob">ScriptJob</a>[]
 
 The list of JobRunners.
 
@@ -3443,6 +3613,51 @@ The JMESPath to find the primary key value in the incoming data stream.
 
 ---
 
+### OutgoingEventDetailTypes <a name="OutgoingEventDetailTypes" id="@cdklabs/sbt-aws.OutgoingEventDetailTypes"></a>
+
+Represents the DetailTypes that can be emitted as part of the outgoing event.
+
+#### Initializer <a name="Initializer" id="@cdklabs/sbt-aws.OutgoingEventDetailTypes.Initializer"></a>
+
+```typescript
+import { OutgoingEventDetailTypes } from '@cdklabs/sbt-aws'
+
+const outgoingEventDetailTypes: OutgoingEventDetailTypes = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@cdklabs/sbt-aws.OutgoingEventDetailTypes.property.failure">failure</a></code> | <code><a href="#@cdklabs/sbt-aws.DetailType">DetailType</a></code> | The detail type for a failed event. |
+| <code><a href="#@cdklabs/sbt-aws.OutgoingEventDetailTypes.property.success">success</a></code> | <code><a href="#@cdklabs/sbt-aws.DetailType">DetailType</a></code> | The detail type for a successful event. |
+
+---
+
+##### `failure`<sup>Required</sup> <a name="failure" id="@cdklabs/sbt-aws.OutgoingEventDetailTypes.property.failure"></a>
+
+```typescript
+public readonly failure: DetailType;
+```
+
+- *Type:* <a href="#@cdklabs/sbt-aws.DetailType">DetailType</a>
+
+The detail type for a failed event.
+
+---
+
+##### `success`<sup>Required</sup> <a name="success" id="@cdklabs/sbt-aws.OutgoingEventDetailTypes.property.success"></a>
+
+```typescript
+public readonly success: DetailType;
+```
+
+- *Type:* <a href="#@cdklabs/sbt-aws.DetailType">DetailType</a>
+
+The detail type for a successful event.
+
+---
+
 ### SampleRegistrationWebPageProps <a name="SampleRegistrationWebPageProps" id="@cdklabs/sbt-aws.SampleRegistrationWebPageProps"></a>
 
 Properties for the SampleRegistrationWebPage construct.
@@ -3525,6 +3740,198 @@ public readonly imageLogoUrl: string;
 - *Default:* Amazon logo
 
 The URL of the image logo to display on the registration page.
+
+---
+
+### ScriptJobProps <a name="ScriptJobProps" id="@cdklabs/sbt-aws.ScriptJobProps"></a>
+
+Encapsulates the list of properties for a ScriptJob.
+
+#### Initializer <a name="Initializer" id="@cdklabs/sbt-aws.ScriptJobProps.Initializer"></a>
+
+```typescript
+import { ScriptJobProps } from '@cdklabs/sbt-aws'
+
+const scriptJobProps: ScriptJobProps = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@cdklabs/sbt-aws.ScriptJobProps.property.eventManager">eventManager</a></code> | <code><a href="#@cdklabs/sbt-aws.IEventManager">IEventManager</a></code> | The EventManager instance that allows connecting to events flowing between the Control Plane and other components. |
+| <code><a href="#@cdklabs/sbt-aws.ScriptJobProps.property.incomingEvent">incomingEvent</a></code> | <code><a href="#@cdklabs/sbt-aws.DetailType">DetailType</a></code> | The incoming event DetailType that triggers this job. |
+| <code><a href="#@cdklabs/sbt-aws.ScriptJobProps.property.jobFailureStatus">jobFailureStatus</a></code> | <code>{[ key: string ]: string}</code> | In the case of failure, this is the object that will be included in the outgoing event `jobOutput` field. |
+| <code><a href="#@cdklabs/sbt-aws.ScriptJobProps.property.jobIdentifierKey">jobIdentifierKey</a></code> | <code>string</code> | The key where the job identifier is to be extracted from in the incoming event. |
+| <code><a href="#@cdklabs/sbt-aws.ScriptJobProps.property.outgoingEvent">outgoingEvent</a></code> | <code><a href="#@cdklabs/sbt-aws.OutgoingEventDetailTypes">OutgoingEventDetailTypes</a></code> | The outgoing event DetailTypes that are emitted upon job success or failure. |
+| <code><a href="#@cdklabs/sbt-aws.ScriptJobProps.property.permissions">permissions</a></code> | <code>aws-cdk-lib.aws_iam.PolicyDocument</code> | The IAM permission document for the ScriptJob. |
+| <code><a href="#@cdklabs/sbt-aws.ScriptJobProps.property.script">script</a></code> | <code>string</code> | The bash script to run as part of the ScriptJob. |
+| <code><a href="#@cdklabs/sbt-aws.ScriptJobProps.property.environmentJSONVariablesFromIncomingEvent">environmentJSONVariablesFromIncomingEvent</a></code> | <code>string[]</code> | The environment variables to import into the ScriptJob from event details field. |
+| <code><a href="#@cdklabs/sbt-aws.ScriptJobProps.property.environmentStringVariablesFromIncomingEvent">environmentStringVariablesFromIncomingEvent</a></code> | <code>string[]</code> | The environment variables to import into the ScriptJob from event details field. |
+| <code><a href="#@cdklabs/sbt-aws.ScriptJobProps.property.environmentVariablesToOutgoingEvent">environmentVariablesToOutgoingEvent</a></code> | <code>string[]</code> | The environment variables to export into the outgoing event once the ScriptJob has finished. |
+| <code><a href="#@cdklabs/sbt-aws.ScriptJobProps.property.postScript">postScript</a></code> | <code>string</code> | The bash script to run after the main script has completed. |
+| <code><a href="#@cdklabs/sbt-aws.ScriptJobProps.property.scriptEnvironmentVariables">scriptEnvironmentVariables</a></code> | <code>{[ key: string ]: string}</code> | The variables to pass into the codebuild ScriptJob. |
+
+---
+
+##### `eventManager`<sup>Required</sup> <a name="eventManager" id="@cdklabs/sbt-aws.ScriptJobProps.property.eventManager"></a>
+
+```typescript
+public readonly eventManager: IEventManager;
+```
+
+- *Type:* <a href="#@cdklabs/sbt-aws.IEventManager">IEventManager</a>
+
+The EventManager instance that allows connecting to events flowing between the Control Plane and other components.
+
+---
+
+##### `incomingEvent`<sup>Required</sup> <a name="incomingEvent" id="@cdklabs/sbt-aws.ScriptJobProps.property.incomingEvent"></a>
+
+```typescript
+public readonly incomingEvent: DetailType;
+```
+
+- *Type:* <a href="#@cdklabs/sbt-aws.DetailType">DetailType</a>
+
+The incoming event DetailType that triggers this job.
+
+---
+
+##### `jobFailureStatus`<sup>Required</sup> <a name="jobFailureStatus" id="@cdklabs/sbt-aws.ScriptJobProps.property.jobFailureStatus"></a>
+
+```typescript
+public readonly jobFailureStatus: {[ key: string ]: string};
+```
+
+- *Type:* {[ key: string ]: string}
+
+In the case of failure, this is the object that will be included in the outgoing event `jobOutput` field.
+
+Ex: If the job fails, the outgoing event will look like this:
+  {'tenantId': 'XXX', 'jobOutput': jobFailureStatus}
+
+---
+
+##### `jobIdentifierKey`<sup>Required</sup> <a name="jobIdentifierKey" id="@cdklabs/sbt-aws.ScriptJobProps.property.jobIdentifierKey"></a>
+
+```typescript
+public readonly jobIdentifierKey: string;
+```
+
+- *Type:* string
+
+The key where the job identifier is to be extracted from in the incoming event.
+
+This will be used as the key that will be populated with
+the job identifier in the outgoing event.
+
+Ex: if jobIdentifierKey == 'tenantId' then
+the incoming event should look something like this:
+  {'tenantId': '123', ....}
+and the outgoing event will look something like this:
+  {'tenantId': '123', 'jobOutput': { ... }}
+
+---
+
+##### `outgoingEvent`<sup>Required</sup> <a name="outgoingEvent" id="@cdklabs/sbt-aws.ScriptJobProps.property.outgoingEvent"></a>
+
+```typescript
+public readonly outgoingEvent: OutgoingEventDetailTypes;
+```
+
+- *Type:* <a href="#@cdklabs/sbt-aws.OutgoingEventDetailTypes">OutgoingEventDetailTypes</a>
+
+The outgoing event DetailTypes that are emitted upon job success or failure.
+
+---
+
+##### `permissions`<sup>Required</sup> <a name="permissions" id="@cdklabs/sbt-aws.ScriptJobProps.property.permissions"></a>
+
+```typescript
+public readonly permissions: PolicyDocument;
+```
+
+- *Type:* aws-cdk-lib.aws_iam.PolicyDocument
+
+The IAM permission document for the ScriptJob.
+
+---
+
+##### `script`<sup>Required</sup> <a name="script" id="@cdklabs/sbt-aws.ScriptJobProps.property.script"></a>
+
+```typescript
+public readonly script: string;
+```
+
+- *Type:* string
+
+The bash script to run as part of the ScriptJob.
+
+---
+
+##### `environmentJSONVariablesFromIncomingEvent`<sup>Optional</sup> <a name="environmentJSONVariablesFromIncomingEvent" id="@cdklabs/sbt-aws.ScriptJobProps.property.environmentJSONVariablesFromIncomingEvent"></a>
+
+```typescript
+public readonly environmentJSONVariablesFromIncomingEvent: string[];
+```
+
+- *Type:* string[]
+
+The environment variables to import into the ScriptJob from event details field.
+
+This argument consists of the names of only JSON-formatted string type variables.
+Ex. '{"test": 2}'
+
+---
+
+##### `environmentStringVariablesFromIncomingEvent`<sup>Optional</sup> <a name="environmentStringVariablesFromIncomingEvent" id="@cdklabs/sbt-aws.ScriptJobProps.property.environmentStringVariablesFromIncomingEvent"></a>
+
+```typescript
+public readonly environmentStringVariablesFromIncomingEvent: string[];
+```
+
+- *Type:* string[]
+
+The environment variables to import into the ScriptJob from event details field.
+
+This argument consists of the names of only string type variables. Ex. 'test'
+
+---
+
+##### `environmentVariablesToOutgoingEvent`<sup>Optional</sup> <a name="environmentVariablesToOutgoingEvent" id="@cdklabs/sbt-aws.ScriptJobProps.property.environmentVariablesToOutgoingEvent"></a>
+
+```typescript
+public readonly environmentVariablesToOutgoingEvent: string[];
+```
+
+- *Type:* string[]
+
+The environment variables to export into the outgoing event once the ScriptJob has finished.
+
+---
+
+##### `postScript`<sup>Optional</sup> <a name="postScript" id="@cdklabs/sbt-aws.ScriptJobProps.property.postScript"></a>
+
+```typescript
+public readonly postScript: string;
+```
+
+- *Type:* string
+
+The bash script to run after the main script has completed.
+
+---
+
+##### `scriptEnvironmentVariables`<sup>Optional</sup> <a name="scriptEnvironmentVariables" id="@cdklabs/sbt-aws.ScriptJobProps.property.scriptEnvironmentVariables"></a>
+
+```typescript
+public readonly scriptEnvironmentVariables: {[ key: string ]: string};
+```
+
+- *Type:* {[ key: string ]: string}
+
+The variables to pass into the codebuild ScriptJob.
 
 ---
 
@@ -3629,6 +4036,134 @@ public readonly tenantManagementTable: TenantManagementTable;
 ```
 
 - *Type:* <a href="#@cdklabs/sbt-aws.TenantManagementTable">TenantManagementTable</a>
+
+---
+
+### TenantLifecycleScriptJobProps <a name="TenantLifecycleScriptJobProps" id="@cdklabs/sbt-aws.TenantLifecycleScriptJobProps"></a>
+
+Encapsulates the list of properties for a ScriptJobs that handle lifecycle management for tenants.
+
+#### Initializer <a name="Initializer" id="@cdklabs/sbt-aws.TenantLifecycleScriptJobProps.Initializer"></a>
+
+```typescript
+import { TenantLifecycleScriptJobProps } from '@cdklabs/sbt-aws'
+
+const tenantLifecycleScriptJobProps: TenantLifecycleScriptJobProps = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@cdklabs/sbt-aws.TenantLifecycleScriptJobProps.property.eventManager">eventManager</a></code> | <code><a href="#@cdklabs/sbt-aws.IEventManager">IEventManager</a></code> | The EventManager instance that allows connecting to events flowing between the Control Plane and other components. |
+| <code><a href="#@cdklabs/sbt-aws.TenantLifecycleScriptJobProps.property.permissions">permissions</a></code> | <code>aws-cdk-lib.aws_iam.PolicyDocument</code> | The IAM permission document for the ScriptJob. |
+| <code><a href="#@cdklabs/sbt-aws.TenantLifecycleScriptJobProps.property.script">script</a></code> | <code>string</code> | The bash script to run as part of the ScriptJob. |
+| <code><a href="#@cdklabs/sbt-aws.TenantLifecycleScriptJobProps.property.environmentJSONVariablesFromIncomingEvent">environmentJSONVariablesFromIncomingEvent</a></code> | <code>string[]</code> | The environment variables to import into the ScriptJob from event details field. |
+| <code><a href="#@cdklabs/sbt-aws.TenantLifecycleScriptJobProps.property.environmentStringVariablesFromIncomingEvent">environmentStringVariablesFromIncomingEvent</a></code> | <code>string[]</code> | The environment variables to import into the ScriptJob from event details field. |
+| <code><a href="#@cdklabs/sbt-aws.TenantLifecycleScriptJobProps.property.environmentVariablesToOutgoingEvent">environmentVariablesToOutgoingEvent</a></code> | <code>string[]</code> | The environment variables to export into the outgoing event once the ScriptJob has finished. |
+| <code><a href="#@cdklabs/sbt-aws.TenantLifecycleScriptJobProps.property.postScript">postScript</a></code> | <code>string</code> | The bash script to run after the main script has completed. |
+| <code><a href="#@cdklabs/sbt-aws.TenantLifecycleScriptJobProps.property.scriptEnvironmentVariables">scriptEnvironmentVariables</a></code> | <code>{[ key: string ]: string}</code> | The variables to pass into the codebuild ScriptJob. |
+
+---
+
+##### `eventManager`<sup>Required</sup> <a name="eventManager" id="@cdklabs/sbt-aws.TenantLifecycleScriptJobProps.property.eventManager"></a>
+
+```typescript
+public readonly eventManager: IEventManager;
+```
+
+- *Type:* <a href="#@cdklabs/sbt-aws.IEventManager">IEventManager</a>
+
+The EventManager instance that allows connecting to events flowing between the Control Plane and other components.
+
+---
+
+##### `permissions`<sup>Required</sup> <a name="permissions" id="@cdklabs/sbt-aws.TenantLifecycleScriptJobProps.property.permissions"></a>
+
+```typescript
+public readonly permissions: PolicyDocument;
+```
+
+- *Type:* aws-cdk-lib.aws_iam.PolicyDocument
+
+The IAM permission document for the ScriptJob.
+
+---
+
+##### `script`<sup>Required</sup> <a name="script" id="@cdklabs/sbt-aws.TenantLifecycleScriptJobProps.property.script"></a>
+
+```typescript
+public readonly script: string;
+```
+
+- *Type:* string
+
+The bash script to run as part of the ScriptJob.
+
+---
+
+##### `environmentJSONVariablesFromIncomingEvent`<sup>Optional</sup> <a name="environmentJSONVariablesFromIncomingEvent" id="@cdklabs/sbt-aws.TenantLifecycleScriptJobProps.property.environmentJSONVariablesFromIncomingEvent"></a>
+
+```typescript
+public readonly environmentJSONVariablesFromIncomingEvent: string[];
+```
+
+- *Type:* string[]
+
+The environment variables to import into the ScriptJob from event details field.
+
+This argument consists of the names of only JSON-formatted string type variables.
+Ex. '{"test": 2}'
+
+---
+
+##### `environmentStringVariablesFromIncomingEvent`<sup>Optional</sup> <a name="environmentStringVariablesFromIncomingEvent" id="@cdklabs/sbt-aws.TenantLifecycleScriptJobProps.property.environmentStringVariablesFromIncomingEvent"></a>
+
+```typescript
+public readonly environmentStringVariablesFromIncomingEvent: string[];
+```
+
+- *Type:* string[]
+
+The environment variables to import into the ScriptJob from event details field.
+
+This argument consists of the names of only string type variables. Ex. 'test'
+
+---
+
+##### `environmentVariablesToOutgoingEvent`<sup>Optional</sup> <a name="environmentVariablesToOutgoingEvent" id="@cdklabs/sbt-aws.TenantLifecycleScriptJobProps.property.environmentVariablesToOutgoingEvent"></a>
+
+```typescript
+public readonly environmentVariablesToOutgoingEvent: string[];
+```
+
+- *Type:* string[]
+
+The environment variables to export into the outgoing event once the ScriptJob has finished.
+
+---
+
+##### `postScript`<sup>Optional</sup> <a name="postScript" id="@cdklabs/sbt-aws.TenantLifecycleScriptJobProps.property.postScript"></a>
+
+```typescript
+public readonly postScript: string;
+```
+
+- *Type:* string
+
+The bash script to run after the main script has completed.
+
+---
+
+##### `scriptEnvironmentVariables`<sup>Optional</sup> <a name="scriptEnvironmentVariables" id="@cdklabs/sbt-aws.TenantLifecycleScriptJobProps.property.scriptEnvironmentVariables"></a>
+
+```typescript
+public readonly scriptEnvironmentVariables: {[ key: string ]: string};
+```
+
+- *Type:* {[ key: string ]: string}
+
+The variables to pass into the codebuild ScriptJob.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@aws-cdk/aws-kinesisfirehose-alpha": "2.140.0-alpha.0",
         "@aws-cdk/aws-kinesisfirehose-destinations-alpha": "2.140.0-alpha.0",
-        "@aws-cdk/aws-lambda-python-alpha": "^2.114.1-alpha.0",
+        "@aws-cdk/aws-lambda-python-alpha": "2.140.0-alpha.0",
         "cdk-nag": "^2.27.230"
       },
       "devDependencies": {
@@ -107,14 +107,14 @@
       }
     },
     "node_modules/@aws-cdk/aws-lambda-python-alpha": {
-      "version": "2.114.1-alpha.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-lambda-python-alpha/-/aws-lambda-python-alpha-2.114.1-alpha.0.tgz",
-      "integrity": "sha512-ozpcGNBrNjfrEOkTC8gpTJu9g1PCKV62NNGV3kE3hOkqjphss9ytwKjIfUIvS+yjqy8D8/BHM0btJKrNur0RoQ==",
+      "version": "2.140.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-lambda-python-alpha/-/aws-lambda-python-alpha-2.140.0-alpha.0.tgz",
+      "integrity": "sha512-tJ4GK4fIGjfHEN38NTYnxiovCB7xoR4sZRQtN9XefzpJKKllKxYMXLMF1PRRiOpewLjEtgupN5JG8Kfl/SRxcQ==",
       "engines": {
         "node": ">= 14.15.0"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.114.1",
+        "aws-cdk-lib": "^2.140.0",
         "constructs": "^10.0.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
   "dependencies": {
     "@aws-cdk/aws-kinesisfirehose-alpha": "2.140.0-alpha.0",
     "@aws-cdk/aws-kinesisfirehose-destinations-alpha": "2.140.0-alpha.0",
-    "@aws-cdk/aws-lambda-python-alpha": "^2.114.1-alpha.0",
+    "@aws-cdk/aws-lambda-python-alpha": "2.140.0-alpha.0",
     "cdk-nag": "^2.27.230"
   },
   "keywords": [

--- a/scripts/sbt-aws.sh
+++ b/scripts/sbt-aws.sh
@@ -441,7 +441,7 @@ case "$1" in
 
 "get-tenant")
   if [ $# -ne 2 ]; then
-    echo "Error: delete-tenant requires tenant id"
+    echo "Error: get-tenant requires tenant id"
     exit 1
   fi
   get_tenant "$2"

--- a/src/control-plane/integ.default.ts
+++ b/src/control-plane/integ.default.ts
@@ -5,7 +5,7 @@ import * as cdk from 'aws-cdk-lib';
 import { CfnRule, EventBus, Rule } from 'aws-cdk-lib/aws-events';
 import { LogGroup, RetentionDays } from 'aws-cdk-lib/aws-logs';
 import { AwsSolutionsChecks } from 'cdk-nag';
-import { CognitoAuth, ControlPlane } from '.';
+import * as sbt from '.';
 import { DestroyPolicySetter } from '../cdk-aspect/destroy-policy-setter';
 
 export interface IntegStackProps extends cdk.StackProps {
@@ -16,11 +16,11 @@ export class IntegStack extends cdk.Stack {
   constructor(scope: cdk.App, id: string, props: IntegStackProps) {
     super(scope, id, props);
 
-    const cognitoAuth = new CognitoAuth(this, 'CognitoAuth', {
+    const cognitoAuth = new sbt.CognitoAuth(this, 'CognitoAuth', {
       setAPIGWScopes: false, // only for testing purposes!
     });
 
-    const controlPlane = new ControlPlane(this, 'ControlPlane', {
+    const controlPlane = new sbt.ControlPlane(this, 'ControlPlane', {
       auth: cognitoAuth,
       systemAdminEmail: props.systemAdminEmail,
     });

--- a/src/control-plane/tenant-management/tenant-management.service.ts
+++ b/src/control-plane/tenant-management/tenant-management.service.ts
@@ -133,20 +133,17 @@ export class TenantManagementService extends Construct {
 
     const tenantUpdateServiceTarget = new ApiDestination(putTenantAPIDestination, {
       pathParameterValues: ['$.detail.tenantId'],
-      event: events.RuleTargetInput.fromEventPath('$.detail.tenantOutput'),
+      event: events.RuleTargetInput.fromEventPath('$.detail.jobOutput'),
     });
 
-    props.eventManager.addTargetToEvent(
-      this,
+    [
       DetailType.PROVISION_SUCCESS,
-      tenantUpdateServiceTarget
-    );
-
-    props.eventManager.addTargetToEvent(
-      this,
+      DetailType.PROVISION_FAILURE,
       DetailType.DEPROVISION_SUCCESS,
-      tenantUpdateServiceTarget
-    );
+      DetailType.DEPROVISION_FAILURE,
+    ].forEach((detailType) => {
+      props.eventManager.addTargetToEvent(this, detailType, tenantUpdateServiceTarget);
+    });
 
     this.table = table;
   }

--- a/src/core-app-plane/core-app-plane.ts
+++ b/src/core-app-plane/core-app-plane.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Construct } from 'constructs';
-import { BashJobRunner } from './bash-job-runner';
+import { ScriptJob } from './script-job';
 import { IEventManager, addTemplateTag } from '../utils';
 
 /**
@@ -14,7 +14,7 @@ export interface CoreApplicationPlaneProps {
   /**
    * The list of JobRunners
    */
-  readonly jobRunnersList?: BashJobRunner[];
+  readonly scriptJobs?: ScriptJob[];
 }
 
 /**
@@ -35,8 +35,8 @@ export class CoreApplicationPlane extends Construct {
     addTemplateTag(this, 'CoreApplicationPlane');
     this.eventManager = props.eventManager;
 
-    props.jobRunnersList?.forEach((jobRunner) => {
-      this.eventManager.addTargetToEvent(this, jobRunner.incomingEvent, jobRunner.eventTarget);
+    props.scriptJobs?.forEach((scriptJob) => {
+      this.eventManager.addTargetToEvent(this, scriptJob.incomingEvent, scriptJob.eventTarget);
     });
   }
 }

--- a/src/core-app-plane/index.ts
+++ b/src/core-app-plane/index.ts
@@ -2,4 +2,5 @@
 // SPDX-License-Identifier: Apache-2.0
 
 export * from './core-app-plane';
-export * from './bash-job-runner';
+export * from './script-job';
+export * from './tenant-lifecycle-script-jobs';

--- a/src/core-app-plane/integ.default.ts
+++ b/src/core-app-plane/integ.default.ts
@@ -6,10 +6,9 @@ import { CfnRule, EventBus, Rule } from 'aws-cdk-lib/aws-events';
 import { Effect, PolicyDocument, PolicyStatement } from 'aws-cdk-lib/aws-iam';
 import { LogGroup, RetentionDays } from 'aws-cdk-lib/aws-logs';
 import { AwsSolutionsChecks, NagSuppressions } from 'cdk-nag';
-import { CoreApplicationPlane } from '.';
-import { BashJobRunner, BashJobRunnerProps } from './bash-job-runner';
+import * as sbt from '.';
 import { DestroyPolicySetter } from '../cdk-aspect/destroy-policy-setter';
-import { DetailType, EventManager } from '../utils';
+import { EventManager } from '../utils';
 
 export interface IntegStackProps extends cdk.StackProps {
   eventBusArn?: string;
@@ -30,7 +29,7 @@ export class IntegStack extends cdk.Stack {
       eventManager = new EventManager(this, 'EventManager');
     }
 
-    const provisioningJobRunnerProps: BashJobRunnerProps = {
+    const provisioningScriptJobProps: sbt.TenantLifecycleScriptJobProps = {
       permissions: new PolicyDocument({
         statements: [
           new PolicyStatement({
@@ -101,12 +100,10 @@ echo "done!"
       scriptEnvironmentVariables: {
         TEST: 'test',
       },
-      outgoingEvent: DetailType.PROVISION_SUCCESS,
-      incomingEvent: DetailType.ONBOARDING_REQUEST,
       eventManager: eventManager,
     };
 
-    const deprovisioningJobRunnerProps: BashJobRunnerProps = {
+    const deprovisioningScriptJobProps: sbt.TenantLifecycleScriptJobProps = {
       permissions: new PolicyDocument({
         statements: [
           new PolicyStatement({
@@ -133,25 +130,23 @@ echo "done!"
 `,
       environmentStringVariablesFromIncomingEvent: ['tenantId'],
       environmentVariablesToOutgoingEvent: ['tenantStatus'],
-      outgoingEvent: DetailType.DEPROVISION_SUCCESS,
-      incomingEvent: DetailType.OFFBOARDING_REQUEST,
       eventManager: eventManager,
     };
 
-    const provisioningJobRunner: BashJobRunner = new BashJobRunner(
+    const provisioningJobScript: sbt.ProvisioningScriptJob = new sbt.ProvisioningScriptJob(
       this,
-      'provisioningJobRunner',
-      provisioningJobRunnerProps
+      'provisioningJobScript',
+      provisioningScriptJobProps
     );
-    const deprovisioningJobRunner: BashJobRunner = new BashJobRunner(
+    const deprovisioningJobScript: sbt.DeprovisioningScriptJob = new sbt.DeprovisioningScriptJob(
       this,
-      'deprovisioningJobRunner',
-      deprovisioningJobRunnerProps
+      'deprovisioningJobScript',
+      deprovisioningScriptJobProps
     );
 
-    new CoreApplicationPlane(this, 'CoreApplicationPlane', {
+    new sbt.CoreApplicationPlane(this, 'CoreApplicationPlane', {
       eventManager: eventManager,
-      jobRunnersList: [provisioningJobRunner, deprovisioningJobRunner],
+      scriptJobs: [provisioningJobScript, deprovisioningJobScript],
     });
 
     const eventBusWatcherRule = new Rule(this, 'EventBusWatcherRule', {
@@ -195,7 +190,7 @@ const integStack = new IntegStack(app, process.env.CDK_PARAM_STACK_ID ?? 'CoreAp
 
 NagSuppressions.addResourceSuppressionsByPath(
   integStack,
-  `/${integStack.artifactId}/deprovisioningJobRunner/codeBuildProvisionProjectRole/Resource`,
+  `/${integStack.artifactId}/provisioningJobScript/codeBuildProvisionProjectRole/Resource`,
   [
     {
       id: 'AwsSolutions-IAM5',
@@ -207,7 +202,7 @@ NagSuppressions.addResourceSuppressionsByPath(
 
 NagSuppressions.addResourceSuppressionsByPath(
   integStack,
-  `/${integStack.artifactId}/provisioningJobRunner/codeBuildProvisionProjectRole/Resource`,
+  `/${integStack.artifactId}/deprovisioningJobScript/codeBuildProvisionProjectRole/Resource`,
   [
     {
       id: 'AwsSolutions-IAM5',

--- a/src/core-app-plane/integ.default.ts
+++ b/src/core-app-plane/integ.default.ts
@@ -85,12 +85,10 @@ export tenantStatus="created"
 
 echo "done!"
 `,
-      postScript: '',
       environmentStringVariablesFromIncomingEvent: ['tenantId', 'tier', 'tenantName', 'email'],
       environmentJSONVariablesFromIncomingEvent: ['prices'],
       environmentVariablesToOutgoingEvent: [
         'tenantS3Bucket',
-        'someOtherVariable',
         'tenantConfig',
         'tenantStatus',
         'prices', // added so we don't lose it for targets beyond provisioning (ex. billing)

--- a/src/core-app-plane/tenant-lifecycle-script-jobs.ts
+++ b/src/core-app-plane/tenant-lifecycle-script-jobs.ts
@@ -1,0 +1,105 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import * as iam from 'aws-cdk-lib/aws-iam';
+import { Construct } from 'constructs';
+import { ScriptJob, ScriptJobProps } from './script-job';
+import { DetailType, IEventManager } from '../utils';
+
+/**
+ * Encapsulates the list of properties for a ScriptJobs that
+ * handle lifecycle management for tenants.
+ */
+export interface TenantLifecycleScriptJobProps {
+  /**
+   * The IAM permission document for the ScriptJob.
+   */
+  readonly permissions: iam.PolicyDocument;
+
+  /**
+   * The bash script to run as part of the ScriptJob.
+   */
+  readonly script: string;
+
+  /**
+   * The bash script to run after the main script has completed.
+   */
+  readonly postScript?: string;
+
+  /**
+   * The environment variables to import into the ScriptJob from event details field.
+   * This argument consists of the names of only string type variables. Ex. 'test'
+   */
+  readonly environmentStringVariablesFromIncomingEvent?: string[];
+
+  /**
+   * The environment variables to import into the ScriptJob from event details field.
+   * This argument consists of the names of only JSON-formatted string type variables.
+   * Ex. '{"test": 2}'
+   */
+  readonly environmentJSONVariablesFromIncomingEvent?: string[];
+
+  /**
+   * The environment variables to export into the outgoing event once the ScriptJob has finished.
+   */
+  readonly environmentVariablesToOutgoingEvent?: string[];
+
+  /**
+   * The variables to pass into the codebuild ScriptJob.
+   */
+  readonly scriptEnvironmentVariables?: {
+    [key: string]: string;
+  };
+
+  /**
+   * The EventManager instance that allows connecting to events flowing between
+   * the Control Plane and other components.
+   */
+  readonly eventManager: IEventManager;
+}
+
+/**
+ * Provides a ProvisioningScriptJob to execute arbitrary bash code.
+ * This is a simple wrapper around ScriptJob that reduces some of the parameters
+ * that need to be configured.
+ */
+export class ProvisioningScriptJob extends ScriptJob {
+  constructor(scope: Construct, id: string, props: TenantLifecycleScriptJobProps) {
+    const scriptJobProps: ScriptJobProps = {
+      ...props,
+      jobIdentifierKey: 'tenantId',
+      jobFailureStatus: {
+        tenantStatus: 'Failed to provision tenant.',
+      },
+      incomingEvent: DetailType.ONBOARDING_REQUEST,
+      outgoingEvent: {
+        success: DetailType.PROVISION_SUCCESS,
+        failure: DetailType.PROVISION_FAILURE,
+      },
+    };
+    super(scope, id, scriptJobProps);
+  }
+}
+
+/**
+ * Provides a ProvisioningScriptJob to execute arbitrary bash code.
+ * This is a simple wrapper around ScriptJob that reduces some of the parameters
+ * that need to be configured.
+ */
+export class DeprovisioningScriptJob extends ScriptJob {
+  constructor(scope: Construct, id: string, props: TenantLifecycleScriptJobProps) {
+    const scriptJobProps: ScriptJobProps = {
+      ...props,
+      jobIdentifierKey: 'tenantId',
+      jobFailureStatus: {
+        tenantStatus: 'Failed to deprovision tenant.',
+      },
+      incomingEvent: DetailType.OFFBOARDING_REQUEST,
+      outgoingEvent: {
+        success: DetailType.DEPROVISION_SUCCESS,
+        failure: DetailType.DEPROVISION_FAILURE,
+      },
+    };
+    super(scope, id, scriptJobProps);
+  }
+}

--- a/src/core-app-plane/tenant-lifecycle-script-jobs.ts
+++ b/src/core-app-plane/tenant-lifecycle-script-jobs.ts
@@ -82,7 +82,7 @@ export class ProvisioningScriptJob extends ScriptJob {
 }
 
 /**
- * Provides a ProvisioningScriptJob to execute arbitrary bash code.
+ * Provides a DeprovisioningScriptJob to execute arbitrary bash code.
  * This is a simple wrapper around ScriptJob that reduces some of the parameters
  * that need to be configured.
  */

--- a/test/core-app-plane.test.ts
+++ b/test/core-app-plane.test.ts
@@ -6,8 +6,8 @@ import { Annotations, Match, Template } from 'aws-cdk-lib/assertions';
 import { PolicyDocument, PolicyStatement, Effect } from 'aws-cdk-lib/aws-iam';
 import { AwsSolutionsChecks, NagSuppressions } from 'cdk-nag';
 import { Construct, IConstruct } from 'constructs';
-import { CoreApplicationPlane, BashJobRunner } from '../src/core-app-plane';
-import { DetailType, EventManager } from '../src/utils';
+import { CoreApplicationPlane, ProvisioningScriptJob } from '../src/core-app-plane';
+import { EventManager } from '../src/utils';
 
 class DestroyPolicySetter implements cdk.IAspect {
   public visit(node: IConstruct): void {
@@ -23,12 +23,10 @@ describe('No unsuppressed cdk-nag Warnings or Errors', () => {
     constructor(scope: Construct, id: string, props?: cdk.StackProps) {
       super(scope, id, props);
       const eventManager = new EventManager(this, 'EventManager');
-      const provisioningJobRunner: BashJobRunner = new BashJobRunner(
+      const provisioningJobScript: ProvisioningScriptJob = new ProvisioningScriptJob(
         this,
-        'provisioningJobRunner',
+        'provisioningJobScript',
         {
-          outgoingEvent: DetailType.PROVISION_SUCCESS,
-          incomingEvent: DetailType.ONBOARDING_REQUEST,
           permissions: new PolicyDocument({
             statements: [
               new PolicyStatement({
@@ -44,7 +42,7 @@ describe('No unsuppressed cdk-nag Warnings or Errors', () => {
       );
       new CoreApplicationPlane(this, 'CoreApplicationPlane', {
         eventManager: eventManager,
-        jobRunnersList: [provisioningJobRunner],
+        scriptJobs: [provisioningJobScript],
       });
     }
   }
@@ -84,12 +82,10 @@ describe('CoreApplicationPlane', () => {
       constructor(scope: Construct, id: string, props?: cdk.StackProps) {
         super(scope, id, props);
         const eventManager = new EventManager(this, 'EventManager');
-        const provisioningJobRunner: BashJobRunner = new BashJobRunner(
+        const provisioningJobScript: ProvisioningScriptJob = new ProvisioningScriptJob(
           this,
-          'provisioningJobRunner',
+          'provisioningJobScript',
           {
-            outgoingEvent: DetailType.PROVISION_SUCCESS,
-            incomingEvent: DetailType.ONBOARDING_REQUEST,
             permissions: new PolicyDocument({
               statements: [
                 new PolicyStatement({
@@ -105,7 +101,7 @@ describe('CoreApplicationPlane', () => {
         );
         new CoreApplicationPlane(this, 'CoreApplicationPlane', {
           eventManager: eventManager,
-          jobRunnersList: [provisioningJobRunner],
+          scriptJobs: [provisioningJobScript],
         });
       }
     }
@@ -130,12 +126,10 @@ describe('CoreApplicationPlane', () => {
       constructor(scope: Construct, id: string, props?: cdk.StackProps) {
         super(scope, id, props);
         const eventManager = new EventManager(this, 'EventManager');
-        const provisioningJobRunner: BashJobRunner = new BashJobRunner(
+        const provisioningJobScript: ProvisioningScriptJob = new ProvisioningScriptJob(
           this,
-          'provisioningJobRunner',
+          'provisioningJobScript',
           {
-            outgoingEvent: DetailType.PROVISION_SUCCESS,
-            incomingEvent: DetailType.ONBOARDING_REQUEST,
             permissions: new PolicyDocument({
               statements: [
                 new PolicyStatement({
@@ -154,7 +148,7 @@ describe('CoreApplicationPlane', () => {
         );
         const coreApplicationPlane = new CoreApplicationPlane(this, 'CoreApplicationPlane', {
           eventManager: eventManager,
-          jobRunnersList: [provisioningJobRunner],
+          scriptJobs: [provisioningJobScript],
         });
         cdk.Aspects.of(coreApplicationPlane).add(new DestroyPolicySetter());
       }


### PR DESCRIPTION
### Issue # (if applicable)

Closes #73 

### Reason for this change

#73 

### Description of changes

This commit refactors the BashJobRunner construct into a more generic ScriptJob construct. It also introduces two new constructs, ProvisioningScriptJob and DeprovisioningScriptJob, which are wrappers around ScriptJob with predefined configurations for tenant provisioning and deprovisioning scenarios.

The main changes include:

- Rename BashJobRunner to ScriptJob and update related interfaces and properties
- Add OutgoingEventDetailTypes interface to represent success and failure detail types
- Introduce ProvisioningScriptJob and DeprovisioningScriptJob constructs
- Update CoreApplicationPlane to use scriptJobs instead of jobRunnersList
- Update integration tests and documentation accordingly

This refactoring provides a more flexible and extensible approach for running arbitrary scripts in the application plane, while also simplifying the configuration for common tenant lifecycle management scenarios.


### Description of how you validated changes

<!--Have you added any unit tests and/or integration tests?-->

### Checklist

- [X] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/sbt-aws/blob/main/CONTRIBUTING.md)
- [X] I have updated the relevant documentation (if applicable).

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the project license.*
