### PR TITLE
feat: add interface for metering component

### DIFF
--- a/src/control-plane/metering/metering-interface.ts
+++ b/src/control-plane/metering/metering-interface.ts
@@ -1,0 +1,66 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { IFunction } from 'aws-cdk-lib/aws-lambda';
+import { DetailType } from '../../utils';
+
+/**
+ * Optional interface that allows specifying both
+ * the function to trigger and the event that will trigger it.
+ */
+export interface IFunctionTrigger {
+  /**
+   * The function definition.
+   */
+  readonly handler: IFunction;
+
+  /**
+   * The detail-type that will trigger the handler function.
+   */
+  readonly trigger: DetailType;
+}
+
+/**
+ * Encapsulates the list of properties for an IMetering construct.
+ */
+export interface IMetering {
+  /**
+   * The function to trigger to create a meter.
+   * Once created, the meter can be used to track and analyze the specific usage metrics for tenants.
+   */
+  createMeterFunction: IFunction | IFunctionTrigger;
+
+  /**
+   * The function to trigger to update a meter.
+   */
+  updateMeterFunction?: IFunction | IFunctionTrigger;
+
+  /**
+   * The function to trigger to ingest a usage event.
+   * Usage events are used to measure and track the usage metrics associated with the meter.
+   */
+  ingestFunction: IFunction | IFunctionTrigger;
+
+  /**
+   * The function to trigger to get the usage data that has been recorded for a specific meter.
+   */
+  getUsageFunction: IFunction | IFunctionTrigger;
+
+  /**
+   * The function to trigger to exclude specific events from being recorded or included in the usage data.
+   * Used for canceling events that were incorrectly ingested.
+   */
+  cancelUsageEventsFunction?: IFunction | IFunctionTrigger;
+
+  /**
+   * The function to trigger to create a new customer.
+   * (Customer in this context is a tenant.)
+   */
+  createCustomerFunction?: IFunction | IFunctionTrigger;
+
+  /**
+   * The function to trigger to delete a customer.
+   * (Customer in this context is a tenant.)
+   */
+  deleteCustomerFunction?: IFunction | IFunctionTrigger;
+}


### PR DESCRIPTION
### Issue # (if applicable)

Closes #<issue number here>.

### Reason for this change

Add metering interface in control plane.

### Description of changes

This pull request introduces a new interface for Metering, a new component in the control plane. The Metering interface aims to provide a standardized way of measuring and tracking resource usage at tenant level across the platform.

### Proposed changes

- Define an IMetering interface with the following methods
  - createMeterFunction
  - updateMeterFunction
  - ingestFunction
  - getUsageFunction
  - cancelUsageEventsFunction
  - createCustomerFunction
  - deleteCustomerFunction
  
### Rationale

By defining a standardized Metering interface, we can enable multiple metering providers to implement their own plugins. This interface provides a clear contract for metering functionality, allowing for seamless integration with the control plane components. 

### Next steps
- Integrate IMetering interface with the Control Plane

### Description of how you validated changes

<!--Have you added any unit tests and/or integration tests?-->

### Checklist

- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/sbt-aws/blob/main/CONTRIBUTING.md)

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the project license.*
