### PR TITLE
feat: connect metering concrete implementation to control plane

### DIFF
--- a/API.md
+++ b/API.md
@@ -3260,6 +3260,7 @@ const controlPlaneProps: ControlPlaneProps = { ... }
 | <code><a href="#@cdklabs/sbt-aws.ControlPlaneProps.property.billing">billing</a></code> | <code><a href="#@cdklabs/sbt-aws.IBilling">IBilling</a></code> | The billing provider configuration. |
 | <code><a href="#@cdklabs/sbt-aws.ControlPlaneProps.property.disableAPILogging">disableAPILogging</a></code> | <code>boolean</code> | If true, the API Gateway will not log requests to the CloudWatch Logs. |
 | <code><a href="#@cdklabs/sbt-aws.ControlPlaneProps.property.eventManager">eventManager</a></code> | <code><a href="#@cdklabs/sbt-aws.IEventManager">IEventManager</a></code> | The event manager instance. |
+| <code><a href="#@cdklabs/sbt-aws.ControlPlaneProps.property.metering">metering</a></code> | <code><a href="#@cdklabs/sbt-aws.IMetering">IMetering</a></code> | The metering provider configuration. |
 | <code><a href="#@cdklabs/sbt-aws.ControlPlaneProps.property.systemAdminName">systemAdminName</a></code> | <code>string</code> | The name of the system admin user. |
 | <code><a href="#@cdklabs/sbt-aws.ControlPlaneProps.property.systemAdminRoleName">systemAdminRoleName</a></code> | <code>string</code> | The name of the system admin role. |
 
@@ -3339,6 +3340,18 @@ public readonly eventManager: IEventManager;
 The event manager instance.
 
 If not provided, a new instance will be created.
+
+---
+
+##### `metering`<sup>Optional</sup> <a name="metering" id="@cdklabs/sbt-aws.ControlPlaneProps.property.metering"></a>
+
+```typescript
+public readonly metering: IMetering;
+```
+
+- *Type:* <a href="#@cdklabs/sbt-aws.IMetering">IMetering</a>
+
+The metering provider configuration.
 
 ---
 
@@ -4803,10 +4816,10 @@ Encapsulates the list of properties for an IBilling construct.
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
-| <code><a href="#@cdklabs/sbt-aws.IBilling.property.createCustomerFunction">createCustomerFunction</a></code> | <code>aws-cdk-lib.aws_lambda.IFunction \| <a href="#@cdklabs/sbt-aws.IFunctionTrigger">IFunctionTrigger</a></code> | The function to trigger to create a new customer. |
-| <code><a href="#@cdklabs/sbt-aws.IBilling.property.deleteCustomerFunction">deleteCustomerFunction</a></code> | <code>aws-cdk-lib.aws_lambda.IFunction \| <a href="#@cdklabs/sbt-aws.IFunctionTrigger">IFunctionTrigger</a></code> | The function to trigger to delete a customer. |
-| <code><a href="#@cdklabs/sbt-aws.IBilling.property.createUserFunction">createUserFunction</a></code> | <code>aws-cdk-lib.aws_lambda.IFunction \| <a href="#@cdklabs/sbt-aws.IFunctionTrigger">IFunctionTrigger</a></code> | The function to trigger to create a new user. |
-| <code><a href="#@cdklabs/sbt-aws.IBilling.property.deleteUserFunction">deleteUserFunction</a></code> | <code>aws-cdk-lib.aws_lambda.IFunction \| <a href="#@cdklabs/sbt-aws.IFunctionTrigger">IFunctionTrigger</a></code> | The function to trigger to delete a user. |
+| <code><a href="#@cdklabs/sbt-aws.IBilling.property.createCustomerFunction">createCustomerFunction</a></code> | <code><a href="#@cdklabs/sbt-aws.IFunctionTrigger">IFunctionTrigger</a> \| aws-cdk-lib.aws_lambda.IFunction</code> | The function to trigger to create a new customer. |
+| <code><a href="#@cdklabs/sbt-aws.IBilling.property.deleteCustomerFunction">deleteCustomerFunction</a></code> | <code><a href="#@cdklabs/sbt-aws.IFunctionTrigger">IFunctionTrigger</a> \| aws-cdk-lib.aws_lambda.IFunction</code> | The function to trigger to delete a customer. |
+| <code><a href="#@cdklabs/sbt-aws.IBilling.property.createUserFunction">createUserFunction</a></code> | <code><a href="#@cdklabs/sbt-aws.IFunctionTrigger">IFunctionTrigger</a> \| aws-cdk-lib.aws_lambda.IFunction</code> | The function to trigger to create a new user. |
+| <code><a href="#@cdklabs/sbt-aws.IBilling.property.deleteUserFunction">deleteUserFunction</a></code> | <code><a href="#@cdklabs/sbt-aws.IFunctionTrigger">IFunctionTrigger</a> \| aws-cdk-lib.aws_lambda.IFunction</code> | The function to trigger to delete a user. |
 | <code><a href="#@cdklabs/sbt-aws.IBilling.property.ingestor">ingestor</a></code> | <code><a href="#@cdklabs/sbt-aws.IDataIngestorAggregator">IDataIngestorAggregator</a></code> | The IDataIngestorAggregator responsible for accepting and aggregating the raw billing data. |
 | <code><a href="#@cdklabs/sbt-aws.IBilling.property.putUsageFunction">putUsageFunction</a></code> | <code>aws-cdk-lib.aws_lambda.IFunction \| <a href="#@cdklabs/sbt-aws.IFunctionSchedule">IFunctionSchedule</a></code> | The function responsible for taking the aggregated data and pushing that to the billing provider. |
 | <code><a href="#@cdklabs/sbt-aws.IBilling.property.webhookFunction">webhookFunction</a></code> | <code>aws-cdk-lib.aws_lambda.IFunction</code> | The function to trigger when a webhook request is received. |
@@ -4817,10 +4830,10 @@ Encapsulates the list of properties for an IBilling construct.
 ##### `createCustomerFunction`<sup>Required</sup> <a name="createCustomerFunction" id="@cdklabs/sbt-aws.IBilling.property.createCustomerFunction"></a>
 
 ```typescript
-public readonly createCustomerFunction: IFunction | IFunctionTrigger;
+public readonly createCustomerFunction: IFunctionTrigger | IFunction;
 ```
 
-- *Type:* aws-cdk-lib.aws_lambda.IFunction | <a href="#@cdklabs/sbt-aws.IFunctionTrigger">IFunctionTrigger</a>
+- *Type:* <a href="#@cdklabs/sbt-aws.IFunctionTrigger">IFunctionTrigger</a> | aws-cdk-lib.aws_lambda.IFunction
 
 The function to trigger to create a new customer.
 
@@ -4831,10 +4844,10 @@ The function to trigger to create a new customer.
 ##### `deleteCustomerFunction`<sup>Required</sup> <a name="deleteCustomerFunction" id="@cdklabs/sbt-aws.IBilling.property.deleteCustomerFunction"></a>
 
 ```typescript
-public readonly deleteCustomerFunction: IFunction | IFunctionTrigger;
+public readonly deleteCustomerFunction: IFunctionTrigger | IFunction;
 ```
 
-- *Type:* aws-cdk-lib.aws_lambda.IFunction | <a href="#@cdklabs/sbt-aws.IFunctionTrigger">IFunctionTrigger</a>
+- *Type:* <a href="#@cdklabs/sbt-aws.IFunctionTrigger">IFunctionTrigger</a> | aws-cdk-lib.aws_lambda.IFunction
 
 The function to trigger to delete a customer.
 
@@ -4845,10 +4858,10 @@ The function to trigger to delete a customer.
 ##### `createUserFunction`<sup>Optional</sup> <a name="createUserFunction" id="@cdklabs/sbt-aws.IBilling.property.createUserFunction"></a>
 
 ```typescript
-public readonly createUserFunction: IFunction | IFunctionTrigger;
+public readonly createUserFunction: IFunctionTrigger | IFunction;
 ```
 
-- *Type:* aws-cdk-lib.aws_lambda.IFunction | <a href="#@cdklabs/sbt-aws.IFunctionTrigger">IFunctionTrigger</a>
+- *Type:* <a href="#@cdklabs/sbt-aws.IFunctionTrigger">IFunctionTrigger</a> | aws-cdk-lib.aws_lambda.IFunction
 
 The function to trigger to create a new user.
 
@@ -4859,10 +4872,10 @@ The function to trigger to create a new user.
 ##### `deleteUserFunction`<sup>Optional</sup> <a name="deleteUserFunction" id="@cdklabs/sbt-aws.IBilling.property.deleteUserFunction"></a>
 
 ```typescript
-public readonly deleteUserFunction: IFunction | IFunctionTrigger;
+public readonly deleteUserFunction: IFunctionTrigger | IFunction;
 ```
 
-- *Type:* aws-cdk-lib.aws_lambda.IFunction | <a href="#@cdklabs/sbt-aws.IFunctionTrigger">IFunctionTrigger</a>
+- *Type:* <a href="#@cdklabs/sbt-aws.IFunctionTrigger">IFunctionTrigger</a> | aws-cdk-lib.aws_lambda.IFunction
 
 The function to trigger to delete a user.
 
@@ -5182,6 +5195,124 @@ The detail-type that will trigger the handler function.
 
 ---
 
+### IMetering <a name="IMetering" id="@cdklabs/sbt-aws.IMetering"></a>
+
+- *Implemented By:* <a href="#@cdklabs/sbt-aws.IMetering">IMetering</a>
+
+Encapsulates the list of properties for an IMetering construct.
+
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@cdklabs/sbt-aws.IMetering.property.createMeterFunction">createMeterFunction</a></code> | <code>aws-cdk-lib.aws_lambda.IFunction</code> | The function to trigger to create a meter -- POST /meters Once created, the meter can be used to track and analyze the specific usage metrics for tenants. |
+| <code><a href="#@cdklabs/sbt-aws.IMetering.property.fetchUsageFunction">fetchUsageFunction</a></code> | <code>aws-cdk-lib.aws_lambda.IFunction</code> | The function to trigger to get the usage data that has been recorded for a specific meter. |
+| <code><a href="#@cdklabs/sbt-aws.IMetering.property.ingestUsageFunction">ingestUsageFunction</a></code> | <code><a href="#@cdklabs/sbt-aws.IFunctionTrigger">IFunctionTrigger</a> \| aws-cdk-lib.aws_lambda.IFunction</code> | The function to trigger to ingest a usage event. |
+| <code><a href="#@cdklabs/sbt-aws.IMetering.property.cancelUsageEventsFunction">cancelUsageEventsFunction</a></code> | <code>aws-cdk-lib.aws_lambda.IFunction</code> | The function to trigger to exclude specific events from being recorded or included in the usage data. |
+| <code><a href="#@cdklabs/sbt-aws.IMetering.property.createCustomerFunction">createCustomerFunction</a></code> | <code><a href="#@cdklabs/sbt-aws.IFunctionTrigger">IFunctionTrigger</a> \| aws-cdk-lib.aws_lambda.IFunction</code> | The function to trigger to create a new customer. (Customer in this context is a tenant.). |
+| <code><a href="#@cdklabs/sbt-aws.IMetering.property.deleteCustomerFunction">deleteCustomerFunction</a></code> | <code><a href="#@cdklabs/sbt-aws.IFunctionTrigger">IFunctionTrigger</a> \| aws-cdk-lib.aws_lambda.IFunction</code> | The function to trigger to delete a customer. (Customer in this context is a tenant.). |
+| <code><a href="#@cdklabs/sbt-aws.IMetering.property.updateMeterFunction">updateMeterFunction</a></code> | <code>aws-cdk-lib.aws_lambda.IFunction</code> | The function to trigger to update a meter -- PUT /meters/meterId. |
+
+---
+
+##### `createMeterFunction`<sup>Required</sup> <a name="createMeterFunction" id="@cdklabs/sbt-aws.IMetering.property.createMeterFunction"></a>
+
+```typescript
+public readonly createMeterFunction: IFunction;
+```
+
+- *Type:* aws-cdk-lib.aws_lambda.IFunction
+
+The function to trigger to create a meter -- POST /meters Once created, the meter can be used to track and analyze the specific usage metrics for tenants.
+
+---
+
+##### `fetchUsageFunction`<sup>Required</sup> <a name="fetchUsageFunction" id="@cdklabs/sbt-aws.IMetering.property.fetchUsageFunction"></a>
+
+```typescript
+public readonly fetchUsageFunction: IFunction;
+```
+
+- *Type:* aws-cdk-lib.aws_lambda.IFunction
+
+The function to trigger to get the usage data that has been recorded for a specific meter.
+
+- GET /usage/meterId
+
+---
+
+##### `ingestUsageFunction`<sup>Required</sup> <a name="ingestUsageFunction" id="@cdklabs/sbt-aws.IMetering.property.ingestUsageFunction"></a>
+
+```typescript
+public readonly ingestUsageFunction: IFunctionTrigger | IFunction;
+```
+
+- *Type:* <a href="#@cdklabs/sbt-aws.IFunctionTrigger">IFunctionTrigger</a> | aws-cdk-lib.aws_lambda.IFunction
+
+The function to trigger to ingest a usage event.
+
+Usage events are used to measure and track the usage metrics associated with the meter.
+
+Default event trigger: INGEST_USAGE
+
+---
+
+##### `cancelUsageEventsFunction`<sup>Optional</sup> <a name="cancelUsageEventsFunction" id="@cdklabs/sbt-aws.IMetering.property.cancelUsageEventsFunction"></a>
+
+```typescript
+public readonly cancelUsageEventsFunction: IFunction;
+```
+
+- *Type:* aws-cdk-lib.aws_lambda.IFunction
+
+The function to trigger to exclude specific events from being recorded or included in the usage data.
+
+Used for canceling events that were incorrectly ingested.
+-- DELETE /usage
+
+---
+
+##### `createCustomerFunction`<sup>Optional</sup> <a name="createCustomerFunction" id="@cdklabs/sbt-aws.IMetering.property.createCustomerFunction"></a>
+
+```typescript
+public readonly createCustomerFunction: IFunctionTrigger | IFunction;
+```
+
+- *Type:* <a href="#@cdklabs/sbt-aws.IFunctionTrigger">IFunctionTrigger</a> | aws-cdk-lib.aws_lambda.IFunction
+
+The function to trigger to create a new customer. (Customer in this context is a tenant.).
+
+Default event trigger: ONBOARDING_REQUEST
+
+---
+
+##### `deleteCustomerFunction`<sup>Optional</sup> <a name="deleteCustomerFunction" id="@cdklabs/sbt-aws.IMetering.property.deleteCustomerFunction"></a>
+
+```typescript
+public readonly deleteCustomerFunction: IFunctionTrigger | IFunction;
+```
+
+- *Type:* <a href="#@cdklabs/sbt-aws.IFunctionTrigger">IFunctionTrigger</a> | aws-cdk-lib.aws_lambda.IFunction
+
+The function to trigger to delete a customer. (Customer in this context is a tenant.).
+
+Default event trigger: OFFBOARDING_REQUEST
+
+---
+
+##### `updateMeterFunction`<sup>Optional</sup> <a name="updateMeterFunction" id="@cdklabs/sbt-aws.IMetering.property.updateMeterFunction"></a>
+
+```typescript
+public readonly updateMeterFunction: IFunction;
+```
+
+- *Type:* aws-cdk-lib.aws_lambda.IFunction
+
+The function to trigger to update a meter -- PUT /meters/meterId.
+
+---
+
 ### IRoute <a name="IRoute" id="@cdklabs/sbt-aws.IRoute"></a>
 
 - *Implemented By:* <a href="#@cdklabs/sbt-aws.IRoute">IRoute</a>
@@ -5306,6 +5437,7 @@ events sent across the EventBus.
 | <code><a href="#@cdklabs/sbt-aws.DetailType.DEACTIVATE_FAILURE">DEACTIVATE_FAILURE</a></code> | Event detail type for failed deactivation. |
 | <code><a href="#@cdklabs/sbt-aws.DetailType.TENANT_USER_CREATED">TENANT_USER_CREATED</a></code> | Event detail type for user creation on the app-plane side. |
 | <code><a href="#@cdklabs/sbt-aws.DetailType.TENANT_USER_DELETED">TENANT_USER_DELETED</a></code> | Event detail type for user deletion on the app-plane side. |
+| <code><a href="#@cdklabs/sbt-aws.DetailType.INGEST_USAGE">INGEST_USAGE</a></code> | Event detail type for ingesting a usage event. |
 
 ---
 
@@ -5451,6 +5583,13 @@ Event detail type for user deletion on the app-plane side.
 
 Note that sbt-aws components do not emit this event. This event
 should be emitted by the application plane.
+
+---
+
+
+##### `INGEST_USAGE` <a name="INGEST_USAGE" id="@cdklabs/sbt-aws.DetailType.INGEST_USAGE"></a>
+
+Event detail type for ingesting a usage event.
 
 ---
 

--- a/API.md
+++ b/API.md
@@ -5208,7 +5208,7 @@ Encapsulates the list of properties for an IMetering construct.
 | --- | --- | --- |
 | <code><a href="#@cdklabs/sbt-aws.IMetering.property.createMeterFunction">createMeterFunction</a></code> | <code>aws-cdk-lib.aws_lambda.IFunction</code> | The function to trigger to create a meter -- POST /meters Once created, the meter can be used to track and analyze the specific usage metrics for tenants. |
 | <code><a href="#@cdklabs/sbt-aws.IMetering.property.fetchUsageFunction">fetchUsageFunction</a></code> | <code>aws-cdk-lib.aws_lambda.IFunction</code> | The function to trigger to get the usage data that has been recorded for a specific meter. |
-| <code><a href="#@cdklabs/sbt-aws.IMetering.property.ingestUsageFunction">ingestUsageFunction</a></code> | <code><a href="#@cdklabs/sbt-aws.IFunctionTrigger">IFunctionTrigger</a> \| aws-cdk-lib.aws_lambda.IFunction</code> | The function to trigger to ingest a usage event. |
+| <code><a href="#@cdklabs/sbt-aws.IMetering.property.ingestUsageEventFunction">ingestUsageEventFunction</a></code> | <code><a href="#@cdklabs/sbt-aws.IFunctionTrigger">IFunctionTrigger</a> \| aws-cdk-lib.aws_lambda.IFunction</code> | The function to trigger to ingest a usage event. |
 | <code><a href="#@cdklabs/sbt-aws.IMetering.property.cancelUsageEventsFunction">cancelUsageEventsFunction</a></code> | <code>aws-cdk-lib.aws_lambda.IFunction</code> | The function to trigger to exclude specific events from being recorded or included in the usage data. |
 | <code><a href="#@cdklabs/sbt-aws.IMetering.property.createCustomerFunction">createCustomerFunction</a></code> | <code><a href="#@cdklabs/sbt-aws.IFunctionTrigger">IFunctionTrigger</a> \| aws-cdk-lib.aws_lambda.IFunction</code> | The function to trigger to create a new customer. (Customer in this context is a tenant.). |
 | <code><a href="#@cdklabs/sbt-aws.IMetering.property.deleteCustomerFunction">deleteCustomerFunction</a></code> | <code><a href="#@cdklabs/sbt-aws.IFunctionTrigger">IFunctionTrigger</a> \| aws-cdk-lib.aws_lambda.IFunction</code> | The function to trigger to delete a customer. (Customer in this context is a tenant.). |
@@ -5242,10 +5242,10 @@ The function to trigger to get the usage data that has been recorded for a speci
 
 ---
 
-##### `ingestUsageFunction`<sup>Required</sup> <a name="ingestUsageFunction" id="@cdklabs/sbt-aws.IMetering.property.ingestUsageFunction"></a>
+##### `ingestUsageEventFunction`<sup>Required</sup> <a name="ingestUsageEventFunction" id="@cdklabs/sbt-aws.IMetering.property.ingestUsageEventFunction"></a>
 
 ```typescript
-public readonly ingestUsageFunction: IFunctionTrigger | IFunction;
+public readonly ingestUsageEventFunction: IFunctionTrigger | IFunction;
 ```
 
 - *Type:* <a href="#@cdklabs/sbt-aws.IFunctionTrigger">IFunctionTrigger</a> | aws-cdk-lib.aws_lambda.IFunction

--- a/API.md
+++ b/API.md
@@ -5210,9 +5210,13 @@ Encapsulates the list of properties for an IMetering construct.
 | <code><a href="#@cdklabs/sbt-aws.IMetering.property.fetchUsageFunction">fetchUsageFunction</a></code> | <code>aws-cdk-lib.aws_lambda.IFunction</code> | The function to trigger to get the usage data that has been recorded for a specific meter. |
 | <code><a href="#@cdklabs/sbt-aws.IMetering.property.ingestUsageEventFunction">ingestUsageEventFunction</a></code> | <code><a href="#@cdklabs/sbt-aws.IFunctionTrigger">IFunctionTrigger</a> \| aws-cdk-lib.aws_lambda.IFunction</code> | The function to trigger to ingest a usage event. |
 | <code><a href="#@cdklabs/sbt-aws.IMetering.property.cancelUsageEventsFunction">cancelUsageEventsFunction</a></code> | <code>aws-cdk-lib.aws_lambda.IFunction</code> | The function to trigger to exclude specific events from being recorded or included in the usage data. |
+| <code><a href="#@cdklabs/sbt-aws.IMetering.property.cancelUsageEventsScope">cancelUsageEventsScope</a></code> | <code>string</code> | The scope required to authorize requests for cancelling usage events. |
 | <code><a href="#@cdklabs/sbt-aws.IMetering.property.createCustomerFunction">createCustomerFunction</a></code> | <code><a href="#@cdklabs/sbt-aws.IFunctionTrigger">IFunctionTrigger</a> \| aws-cdk-lib.aws_lambda.IFunction</code> | The function to trigger to create a new customer. (Customer in this context is a tenant.). |
+| <code><a href="#@cdklabs/sbt-aws.IMetering.property.createMeterScope">createMeterScope</a></code> | <code>string</code> | The scope required to authorize requests for creating a new meter. |
 | <code><a href="#@cdklabs/sbt-aws.IMetering.property.deleteCustomerFunction">deleteCustomerFunction</a></code> | <code><a href="#@cdklabs/sbt-aws.IFunctionTrigger">IFunctionTrigger</a> \| aws-cdk-lib.aws_lambda.IFunction</code> | The function to trigger to delete a customer. (Customer in this context is a tenant.). |
+| <code><a href="#@cdklabs/sbt-aws.IMetering.property.fetchUsageScope">fetchUsageScope</a></code> | <code>string</code> | The scope required to authorize requests for fetching metering usage. |
 | <code><a href="#@cdklabs/sbt-aws.IMetering.property.updateMeterFunction">updateMeterFunction</a></code> | <code>aws-cdk-lib.aws_lambda.IFunction</code> | The function to trigger to update a meter -- PUT /meters/meterId. |
+| <code><a href="#@cdklabs/sbt-aws.IMetering.property.updateMeterScope">updateMeterScope</a></code> | <code>string</code> | The scope required to authorize requests for updating a meter. |
 
 ---
 
@@ -5273,6 +5277,18 @@ Used for canceling events that were incorrectly ingested.
 
 ---
 
+##### `cancelUsageEventsScope`<sup>Optional</sup> <a name="cancelUsageEventsScope" id="@cdklabs/sbt-aws.IMetering.property.cancelUsageEventsScope"></a>
+
+```typescript
+public readonly cancelUsageEventsScope: string;
+```
+
+- *Type:* string
+
+The scope required to authorize requests for cancelling usage events.
+
+---
+
 ##### `createCustomerFunction`<sup>Optional</sup> <a name="createCustomerFunction" id="@cdklabs/sbt-aws.IMetering.property.createCustomerFunction"></a>
 
 ```typescript
@@ -5284,6 +5300,18 @@ public readonly createCustomerFunction: IFunctionTrigger | IFunction;
 The function to trigger to create a new customer. (Customer in this context is a tenant.).
 
 Default event trigger: ONBOARDING_REQUEST
+
+---
+
+##### `createMeterScope`<sup>Optional</sup> <a name="createMeterScope" id="@cdklabs/sbt-aws.IMetering.property.createMeterScope"></a>
+
+```typescript
+public readonly createMeterScope: string;
+```
+
+- *Type:* string
+
+The scope required to authorize requests for creating a new meter.
 
 ---
 
@@ -5301,6 +5329,18 @@ Default event trigger: OFFBOARDING_REQUEST
 
 ---
 
+##### `fetchUsageScope`<sup>Optional</sup> <a name="fetchUsageScope" id="@cdklabs/sbt-aws.IMetering.property.fetchUsageScope"></a>
+
+```typescript
+public readonly fetchUsageScope: string;
+```
+
+- *Type:* string
+
+The scope required to authorize requests for fetching metering usage.
+
+---
+
 ##### `updateMeterFunction`<sup>Optional</sup> <a name="updateMeterFunction" id="@cdklabs/sbt-aws.IMetering.property.updateMeterFunction"></a>
 
 ```typescript
@@ -5310,6 +5350,18 @@ public readonly updateMeterFunction: IFunction;
 - *Type:* aws-cdk-lib.aws_lambda.IFunction
 
 The function to trigger to update a meter -- PUT /meters/meterId.
+
+---
+
+##### `updateMeterScope`<sup>Optional</sup> <a name="updateMeterScope" id="@cdklabs/sbt-aws.IMetering.property.updateMeterScope"></a>
+
+```typescript
+public readonly updateMeterScope: string;
+```
+
+- *Type:* string
+
+The scope required to authorize requests for updating a meter.
 
 ---
 

--- a/src/control-plane/billing/billing-interface.ts
+++ b/src/control-plane/billing/billing-interface.ts
@@ -3,24 +3,8 @@
 
 import { Schedule } from 'aws-cdk-lib/aws-events';
 import { IFunction } from 'aws-cdk-lib/aws-lambda';
-import { DetailType } from '../../utils';
+import { IFunctionTrigger } from '../../utils';
 import { IDataIngestorAggregator } from '../ingestor-aggregator/ingestor-aggregator-interface';
-
-/**
- * Optional interface that allows specifying both
- * the function to trigger and the event that will trigger it.
- */
-export interface IFunctionTrigger {
-  /**
-   * The function definition.
-   */
-  readonly handler: IFunction;
-
-  /**
-   * The detail-type that will trigger the handler function.
-   */
-  readonly trigger: DetailType;
-}
 
 /**
  * Optional interface that allows specifying both

--- a/src/control-plane/control-plane.ts
+++ b/src/control-plane/control-plane.ts
@@ -151,7 +151,7 @@ export class ControlPlane extends Construct {
     if (props.metering) {
       new MeteringProvider(this, 'Metering', {
         metering: props.metering,
-        controlPlaneAPI: api.api,
+        api: api,
         eventManager: eventManager,
       });
     }

--- a/src/control-plane/control-plane.ts
+++ b/src/control-plane/control-plane.ts
@@ -9,6 +9,8 @@ import { IAuth } from './auth/auth-interface';
 import { CognitoAuth } from './auth/cognito-auth';
 import { BillingProvider, IBilling } from './billing';
 import { ControlPlaneAPI } from './control-plane-api';
+import { IMetering } from './metering';
+import { MeteringProvider } from './metering/metering-provider';
 import { TenantConfigService } from './tenant-config';
 import { TenantManagementService } from './tenant-management/tenant-management.service';
 import { UserManagementService } from './user-management/user-management.service';
@@ -43,6 +45,11 @@ export interface ControlPlaneProps {
    * The billing provider configuration.
    */
   readonly billing?: IBilling;
+
+  /**
+   * The metering provider configuration.
+   */
+  readonly metering?: IMetering;
 
   /**
    * The event manager instance. If not provided, a new instance will be created.
@@ -140,6 +147,15 @@ export class ControlPlane extends Construct {
         });
       }
     }
+
+    if (props.metering) {
+      new MeteringProvider(this, 'Metering', {
+        metering: props.metering,
+        controlPlaneAPI: api.api,
+        eventManager: eventManager,
+      });
+    }
+
     this.eventManager = eventManager;
 
     // defined suppression here to suppress EventsRole Default policy

--- a/src/control-plane/index.ts
+++ b/src/control-plane/index.ts
@@ -11,3 +11,4 @@ export * from './ingestor-aggregator/index';
 export * from './tenant-config';
 export * from './tenant-management';
 export * from './user-management';
+export * from './metering';

--- a/src/control-plane/metering/index.ts
+++ b/src/control-plane/metering/index.ts
@@ -1,0 +1,4 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+export * from './metering-interface';

--- a/src/control-plane/metering/metering-interface.ts
+++ b/src/control-plane/metering/metering-interface.ts
@@ -25,7 +25,7 @@ export interface IMetering {
    *
    * Default event trigger: INGEST_USAGE
    */
-  ingestUsageFunction: IFunction | IFunctionTrigger;
+  ingestUsageEventFunction: IFunction | IFunctionTrigger;
 
   /**
    * The function to trigger to get the usage data that has been recorded for a specific meter.

--- a/src/control-plane/metering/metering-interface.ts
+++ b/src/control-plane/metering/metering-interface.ts
@@ -15,9 +15,19 @@ export interface IMetering {
   createMeterFunction: IFunction;
 
   /**
+   * The scope required to authorize requests for creating a new meter.
+   */
+  createMeterScope?: string;
+
+  /**
    * The function to trigger to update a meter -- PUT /meters/meterId
    */
   updateMeterFunction?: IFunction;
+
+  /**
+   * The scope required to authorize requests for updating a meter.
+   */
+  updateMeterScope?: string;
 
   /**
    * The function to trigger to ingest a usage event.
@@ -34,11 +44,21 @@ export interface IMetering {
   fetchUsageFunction: IFunction; // use 'fetch*' instead of 'get*' to avoid error JSII5000
 
   /**
+   * The scope required to authorize requests for fetching metering usage.
+   */
+  fetchUsageScope?: string;
+
+  /**
    * The function to trigger to exclude specific events from being recorded or included in the usage data.
    * Used for canceling events that were incorrectly ingested.
    * -- DELETE /usage
    */
   cancelUsageEventsFunction?: IFunction;
+
+  /**
+   * The scope required to authorize requests for cancelling usage events.
+   */
+  cancelUsageEventsScope?: string;
 
   /**
    * The function to trigger to create a new customer.

--- a/src/control-plane/metering/metering-interface.ts
+++ b/src/control-plane/metering/metering-interface.ts
@@ -2,65 +2,57 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { IFunction } from 'aws-cdk-lib/aws-lambda';
-import { DetailType } from '../../utils';
-
-/**
- * Optional interface that allows specifying both
- * the function to trigger and the event that will trigger it.
- */
-export interface IFunctionTrigger {
-  /**
-   * The function definition.
-   */
-  readonly handler: IFunction;
-
-  /**
-   * The detail-type that will trigger the handler function.
-   */
-  readonly trigger: DetailType;
-}
+import { IFunctionTrigger } from '../../utils';
 
 /**
  * Encapsulates the list of properties for an IMetering construct.
  */
 export interface IMetering {
   /**
-   * The function to trigger to create a meter.
+   * The function to trigger to create a meter -- POST /meters
    * Once created, the meter can be used to track and analyze the specific usage metrics for tenants.
    */
-  createMeterFunction: IFunction | IFunctionTrigger;
+  createMeterFunction: IFunction;
 
   /**
-   * The function to trigger to update a meter.
+   * The function to trigger to update a meter -- PUT /meters/meterId
    */
-  updateMeterFunction?: IFunction | IFunctionTrigger;
+  updateMeterFunction?: IFunction;
 
   /**
    * The function to trigger to ingest a usage event.
    * Usage events are used to measure and track the usage metrics associated with the meter.
+   *
+   * Default event trigger: INGEST_USAGE
    */
-  ingestFunction: IFunction | IFunctionTrigger;
+  ingestUsageFunction: IFunction | IFunctionTrigger;
 
   /**
    * The function to trigger to get the usage data that has been recorded for a specific meter.
+   * -- GET /usage/meterId
    */
-  getUsageFunction: IFunction | IFunctionTrigger;
+  fetchUsageFunction: IFunction; // use 'fetch*' instead of 'get*' to avoid error JSII5000
 
   /**
    * The function to trigger to exclude specific events from being recorded or included in the usage data.
    * Used for canceling events that were incorrectly ingested.
+   * -- DELETE /usage
    */
-  cancelUsageEventsFunction?: IFunction | IFunctionTrigger;
+  cancelUsageEventsFunction?: IFunction;
 
   /**
    * The function to trigger to create a new customer.
    * (Customer in this context is a tenant.)
+   *
+   * Default event trigger: ONBOARDING_REQUEST
    */
   createCustomerFunction?: IFunction | IFunctionTrigger;
 
   /**
    * The function to trigger to delete a customer.
    * (Customer in this context is a tenant.)
+   *
+   * Default event trigger: OFFBOARDING_REQUEST
    */
   deleteCustomerFunction?: IFunction | IFunctionTrigger;
 }

--- a/src/control-plane/metering/metering-provider.ts
+++ b/src/control-plane/metering/metering-provider.ts
@@ -1,0 +1,114 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import * as apigatewayV2 from 'aws-cdk-lib/aws-apigatewayv2';
+import * as apigatewayV2Integrations from 'aws-cdk-lib/aws-apigatewayv2-integrations';
+import { IFunction } from 'aws-cdk-lib/aws-lambda';
+import { Construct } from 'constructs';
+import { IMetering } from './metering-interface';
+import * as utils from '../../utils';
+
+/**
+ * Encapsulates the list of properties for a MeteringProvider.
+ */
+export interface MeteringProviderProps {
+  /**
+   * An implementation of the IMetering interface.
+   */
+  readonly metering: IMetering;
+
+  /**
+   * An IEventManager object to help coordinate events.
+   */
+  readonly eventManager: utils.IEventManager;
+
+  /**
+   * An API Gateway Resource for the BillingProvider to use
+   * when setting up API endpoints.
+   */
+  readonly controlPlaneAPI: apigatewayV2.HttpApi;
+}
+
+/**
+ * Represents a Metering Provider that handles metering-related operations and
+ * connects the concrete IMetering implementation (provided via props.metering)
+ * to the control plane.
+ *
+ * This construct sets up event targets for various metering-related events
+ * and adds API routes for 'usage' and 'meters'.
+ */
+export class MeteringProvider extends Construct {
+  constructor(scope: Construct, id: string, props: MeteringProviderProps) {
+    super(scope, id);
+    utils.addTemplateTag(this, 'MeteringProvider');
+
+    const usagePath = '/usage';
+    const metersPath = '/meters';
+    const functionTriggerMappings: {
+      defaultFunctionTrigger: utils.DetailType;
+      functionDefinition?: IFunction | utils.IFunctionTrigger;
+    }[] = [
+      {
+        defaultFunctionTrigger: utils.DetailType.ONBOARDING_REQUEST,
+        functionDefinition: props.metering.createCustomerFunction,
+      },
+      {
+        defaultFunctionTrigger: utils.DetailType.OFFBOARDING_REQUEST,
+        functionDefinition: props.metering.deleteCustomerFunction,
+      },
+      {
+        defaultFunctionTrigger: utils.DetailType.INGEST_USAGE,
+        functionDefinition: props.metering.ingestUsageFunction,
+      },
+    ];
+
+    functionTriggerMappings.forEach((target) => {
+      utils.createEventTarget(
+        this,
+        props.eventManager,
+        target.defaultFunctionTrigger,
+        target.functionDefinition
+      );
+    });
+
+    props.controlPlaneAPI.addRoutes({
+      path: `${usagePath}/meterId`,
+      methods: [apigatewayV2.HttpMethod.GET],
+      integration: new apigatewayV2Integrations.HttpLambdaIntegration(
+        'fetchUsageHttpLambdaIntegration',
+        props.metering.fetchUsageFunction
+      ),
+    });
+
+    if (props.metering.cancelUsageEventsFunction) {
+      props.controlPlaneAPI.addRoutes({
+        path: usagePath,
+        methods: [apigatewayV2.HttpMethod.DELETE],
+        integration: new apigatewayV2Integrations.HttpLambdaIntegration(
+          'deleteUsageHttpLambdaIntegration',
+          props.metering.cancelUsageEventsFunction
+        ),
+      });
+    }
+
+    props.controlPlaneAPI.addRoutes({
+      path: metersPath,
+      methods: [apigatewayV2.HttpMethod.POST],
+      integration: new apigatewayV2Integrations.HttpLambdaIntegration(
+        'createMeterHttpLambdaIntegration',
+        props.metering.createMeterFunction
+      ),
+    });
+
+    if (props.metering.updateMeterFunction) {
+      props.controlPlaneAPI.addRoutes({
+        path: `${metersPath}/meterId`,
+        methods: [apigatewayV2.HttpMethod.PUT],
+        integration: new apigatewayV2Integrations.HttpLambdaIntegration(
+          'updateMeterHttpLambdaIntegration',
+          props.metering.updateMeterFunction
+        ),
+      });
+    }
+  }
+}

--- a/src/control-plane/metering/metering-provider.ts
+++ b/src/control-plane/metering/metering-provider.ts
@@ -58,7 +58,7 @@ export class MeteringProvider extends Construct {
       },
       {
         defaultFunctionTrigger: utils.DetailType.INGEST_USAGE,
-        functionDefinition: props.metering.ingestUsageFunction,
+        functionDefinition: props.metering.ingestUsageEventFunction,
       },
     ];
 

--- a/src/utils/event-manager.ts
+++ b/src/utils/event-manager.ts
@@ -103,6 +103,11 @@ export enum DetailType {
    * should be emitted by the application plane.
    */
   TENANT_USER_DELETED = 'tenantUserDeleted',
+
+  /**
+   * Event detail type for ingesting a usage event.
+   */
+  INGEST_USAGE = 'ingestUsage',
 }
 
 /**
@@ -252,6 +257,7 @@ export class EventManager extends Construct implements IEventManager {
       deactivateFailure: this.applicationPlaneEventSource,
       tenantUserCreated: this.controlPlaneEventSource,
       tenantUserDeleted: this.controlPlaneEventSource,
+      ingestUsage: this.applicationPlaneEventSource,
     };
 
     for (const key in this.supportedEvents) {

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -3,7 +3,10 @@
 
 import { Stack } from 'aws-cdk-lib';
 import * as apigatewayV2 from 'aws-cdk-lib/aws-apigatewayv2';
+import * as targets from 'aws-cdk-lib/aws-events-targets';
+import { IFunction } from 'aws-cdk-lib/aws-lambda';
 import { Construct } from 'constructs';
+import { DetailType, IEventManager } from './event-manager';
 
 export const addTemplateTag = (construct: Construct, tag: string) => {
   const stackDesc = Stack.of(construct).templateOptions.description;
@@ -100,4 +103,52 @@ export const generateRoutes = (
     ];
   });
   return allRoutes;
+};
+
+/**
+ * Optional interface that allows specifying both
+ * the function to trigger and the event that will trigger it.
+ */
+export interface IFunctionTrigger {
+  /**
+   * The function definition.
+   */
+  readonly handler: IFunction;
+
+  /**
+   * The detail-type that will trigger the handler function.
+   */
+  readonly trigger: DetailType;
+}
+
+/**
+ * Helper function for attaching functions to events.
+ * If an IFunction is passed in as the argument for functionOrFunctionTrigger, then
+ * the defaultEvent is used as the trigger for the IFunction.
+ *
+ * If an IFunctionTrigger is passed in as the argument for functionOrFunctionTrigger, then
+ * the trigger property of the IFunctionTrigger is used as the trigger for the IFunction.
+ *
+ * If the functionOrFunctionTrigger is not passed in, no event is created.
+ */
+export const createEventTarget = (
+  scope: Construct,
+  eventManager: IEventManager,
+  defaultEvent: DetailType,
+  functionOrFunctionTrigger?: IFunction | IFunctionTrigger
+) => {
+  if (!functionOrFunctionTrigger) {
+    return;
+  }
+
+  let handler: IFunction, trigger: DetailType;
+  if ('handler' in functionOrFunctionTrigger) {
+    handler = functionOrFunctionTrigger.handler;
+    trigger = functionOrFunctionTrigger.trigger;
+  } else {
+    handler = functionOrFunctionTrigger;
+    trigger = defaultEvent;
+  }
+
+  eventManager.addTargetToEvent(scope, trigger, new targets.LambdaFunction(handler));
 };


### PR DESCRIPTION
### Issue # (if applicable)

Closes #<issue number here>.

### Reason for this change

The primary reason for these changes is to introduce a new construct called `MeteringProvider` that handles metering-related operations and integrates with the control plane.

### Description of changes

1. **`MeteringProvider` construct**: I created a new construct called `MeteringProvider` that encapsulates the metering-related functionality. This construct takes an implementation of the `IMetering` interface as a prop and sets up the necessary event targets and API routes for metering operations. Specifically, it:
   - Attaches functions to handle events like `ONBOARDING_REQUEST`, `OFFBOARDING_REQUEST`, and `INGEST_USAGE`.
   - Adds API routes for creating meters (`POST /meters`), updating meters (`PUT /meters/{meterId}`), fetching usage data (`GET /usage/{meterId}`), and canceling usage events (`DELETE /usage`).

2. **Integration with `ControlPlane`**: I updated the `ControlPlane` construct to accept an optional `metering` prop of type `IMetering`. If provided, it creates an instance of the `MeteringProvider` and passes the `metering` implementation to it.


### Description of how you validated changes

<!--Have you added any unit tests and/or integration tests?-->

### Checklist

- [X] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/sbt-aws/blob/main/CONTRIBUTING.md)
- [X] I have updated the relevant documentation (if applicable).

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the project license.*
