### PR TITLE
fix: use proper pathing for nagsuppression of cdk-managed resources

### DIFF
--- a/src/control-plane/auth/cognito-auth.ts
+++ b/src/control-plane/auth/cognito-auth.ts
@@ -477,26 +477,29 @@ export class CognitoAuth extends Construct implements IAuth {
     this.enableUserFunction = userManagementServices;
 
     // https://github.com/aws/aws-cdk/issues/23204
-    NagSuppressions.addResourceSuppressionsByPath(
-      cdk.Stack.of(this),
-      [
-        `/${cdk.Stack.of(this).stackName}/AWS679f53fac002430cb0da5b7982bd2287/ServiceRole/Resource`,
-        `/${cdk.Stack.of(this).stackName}/AWS679f53fac002430cb0da5b7982bd2287/Resource`,
-      ],
-      [
-        {
-          id: 'AwsSolutions-IAM4',
-          reason: 'Suppress usage of AWSLambdaBasicExecutionRole.',
-          appliesTo: [
-            'Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole',
-          ],
-        },
-        {
-          id: 'AwsSolutions-L1',
-          reason: 'NODEJS 18 is the version used in the official quickstart CFN template.',
-        },
-      ]
-    );
+    if (cdk.Stack.of(this).node.tryFindChild('AWS679f53fac002430cb0da5b7982bd2287')) {
+      const AWS679f53fac002430cb0da5b7982bd2287 = cdk.Stack.of(this).node.findChild(
+        'AWS679f53fac002430cb0da5b7982bd2287'
+      );
+      NagSuppressions.addResourceSuppressionsByPath(
+        cdk.Stack.of(this),
+        [AWS679f53fac002430cb0da5b7982bd2287.node.path],
+        [
+          {
+            id: 'AwsSolutions-IAM4',
+            reason: 'Suppress usage of AWSLambdaBasicExecutionRole.',
+            appliesTo: [
+              'Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole',
+            ],
+          },
+          {
+            id: 'AwsSolutions-L1',
+            reason: 'NODEJS 18 is the version used in the official quickstart CFN template.',
+          },
+        ],
+        true
+      );
+    }
 
     this.createAdminUserFunction = new PythonFunction(this, 'createAdminUserFunction', {
       entry: path.join(__dirname, '../../../resources/functions/auth-custom-resource'),

--- a/src/control-plane/aws-marketplace/sample-registration-web-page.ts
+++ b/src/control-plane/aws-marketplace/sample-registration-web-page.ts
@@ -92,39 +92,44 @@ export class SampleRegistrationWebPage extends Construct {
 
     dynamicFile.node.addDependency(staticFiles);
 
-    NagSuppressions.addResourceSuppressionsByPath(
-      cdk.Stack.of(this),
-      [
-        `${cdk.Stack.of(this).stackName}/Custom::CDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C`,
-      ],
-      [
-        {
-          id: 'AwsSolutions-IAM4',
-          reason: 'Suppress usage of AWSLambdaBasicExecutionRole.',
-          appliesTo: [
-            'Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole',
-          ],
-        },
-        {
-          id: 'AwsSolutions-IAM5',
-          reason: 'Allow wildcard access for CDKBucketDeployment.',
-          appliesTo: [
-            'Action::s3:GetObject*',
-            'Action::s3:GetBucket*',
-            'Action::s3:List*',
-            `Resource::arn:<AWS::Partition>:s3:::cdk-${cdk.DefaultStackSynthesizer.DEFAULT_QUALIFIER}-assets-<AWS::AccountId>-${region}/*`,
-            'Action::s3:DeleteObject*',
-            'Action::s3:Abort*',
-            `Resource::<${cdk.Stack.of(this).getLogicalId(websiteBucket.node.defaultChild as s3.CfnBucket)}.Arn>/*`,
-          ],
-        },
-        {
-          id: 'AwsSolutions-L1',
-          reason: 'NODEJS 18 is the version used cdk maanged custom resource.',
-        },
-      ],
-      true
-    );
+    if (
+      cdk.Stack.of(this).node.tryFindChild('CDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C')
+    ) {
+      const CDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C = cdk.Stack.of(this).node.findChild(
+        'CDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C'
+      );
+      NagSuppressions.addResourceSuppressionsByPath(
+        cdk.Stack.of(this),
+        [CDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C.node.path],
+        [
+          {
+            id: 'AwsSolutions-IAM4',
+            reason: 'Suppress usage of AWSLambdaBasicExecutionRole.',
+            appliesTo: [
+              'Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole',
+            ],
+          },
+          {
+            id: 'AwsSolutions-IAM5',
+            reason: 'Allow wildcard access for CDKBucketDeployment.',
+            appliesTo: [
+              'Action::s3:GetObject*',
+              'Action::s3:GetBucket*',
+              'Action::s3:List*',
+              `Resource::arn:<AWS::Partition>:s3:::cdk-${cdk.DefaultStackSynthesizer.DEFAULT_QUALIFIER}-assets-<AWS::AccountId>-${region}/*`,
+              'Action::s3:DeleteObject*',
+              'Action::s3:Abort*',
+              `Resource::<${cdk.Stack.of(this).getLogicalId(websiteBucket.node.defaultChild as s3.CfnBucket)}.Arn>/*`,
+            ],
+          },
+          {
+            id: 'AwsSolutions-L1',
+            reason: 'NODEJS 18 is the version used cdk maanged custom resource.',
+          },
+        ],
+        true
+      );
+    }
 
     const logBucket = new s3.Bucket(this, 'WebsiteS3BucketLog', {
       enforceSSL: true,

--- a/test/control-plane.test.ts
+++ b/test/control-plane.test.ts
@@ -27,7 +27,7 @@ describe('No unsuppressed cdk-nag Warnings or Errors', () => {
 
   const stack = new ControlPlaneStack(app, 'ControlPlaneStack');
 
-  cdk.Aspects.of(stack).add(new AwsSolutionsChecks({ verbose: true }));
+  cdk.Aspects.of(app).add(new AwsSolutionsChecks({ verbose: true }));
 
   it('should have no unsuppressed Warnings', () => {
     const warnings = Annotations.fromStack(stack).findWarning(


### PR DESCRIPTION
### Issue # (if applicable)

Closes #84 

### Reason for this change

Fix NagSuppression issue when using SBT in pipeline stage.

### Description of changes

Use `findChild()` function to get the proper path of the resource instead of hardcoding it based on resource ID.

### Description of how you validated changes

Replicated the template outlined in #84 and made sure the error was resolved.

### Checklist

- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/sbt-aws/blob/main/CONTRIBUTING.md)
- [x] I have updated the relevant documentation (if applicable).

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the project license.*
