### PR TITLE
fix: set removal policy when auto deleting firehose bucket objects

### DIFF
--- a/src/control-plane/ingestor-aggregator/firehose-ingestor-aggregator.ts
+++ b/src/control-plane/ingestor-aggregator/firehose-ingestor-aggregator.ts
@@ -81,6 +81,7 @@ export class FirehoseAggregator extends Construct implements IDataIngestorAggreg
     const firehoseDestinationBucket = new s3.Bucket(this, 'FirehoseDestinationBucket', {
       enforceSSL: true,
       autoDeleteObjects: props.autoDeleteObjects,
+      ...(props.autoDeleteObjects && { removalPolicy: cdk.RemovalPolicy.DESTROY }),
       blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
     });
 


### PR DESCRIPTION
### Issue # (if applicable)

Closes #<issue number here>.

### Reason for this change

This fixes the error that occurs when auto deleting firehose destination bucket. The fix was to set the removal policy to destroy the bucket.

### Description of changes

<!--What code changes did you make? Have you made any important design decisions?-->

### Description of how you validated changes

<!--Have you added any unit tests and/or integration tests?-->

### Checklist

- [ ] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/sbt-aws/blob/main/CONTRIBUTING.md)
- [ ] I have updated the relevant documentation (if applicable).

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the project license.*
