### PR TITLE
feat: Add `selfSignUpEnabled` option to CognitoAuth for user pool configuration

### DIFF
--- a/src/control-plane/auth/cognito-auth.ts
+++ b/src/control-plane/auth/cognito-auth.ts
@@ -35,6 +35,12 @@ export interface CognitoAuthProps {
    * @default true
    */
   readonly setAPIGWScopes?: boolean;
+
+  /**
+   * Whether or not to enable self-signup for the user pool.
+   * @default false
+   */
+  readonly selfSignUpEnabled?: boolean;
 }
 
 /**
@@ -249,6 +255,7 @@ export class CognitoAuth extends Construct implements IAuth {
         userRole: new cognito.StringAttribute({ mutable: true, minLen: 1, maxLen: 256 }),
       },
       advancedSecurityMode: cognito.AdvancedSecurityMode.ENFORCED,
+      selfSignUpEnabled: props?.selfSignUpEnabled || false,
     });
 
     NagSuppressions.addResourceSuppressions(this.userPool, [


### PR DESCRIPTION
### **PR Type**
Feature, Enhancement

___

### **PR Description**
- Added `selfSignUpEnabled` option to `CognitoAuthProps` interface.

- Integrated `selfSignUpEnabled` into Cognito user pool configuration.

- Default value for `selfSignUpEnabled` set to `false`.

- Enhanced flexibility for user pool self-signup configuration.

### Checklist

- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/sbt-aws/blob/main/CONTRIBUTING.md)
- [x] I have updated the relevant documentation (if applicable).

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the project license.*
