### PR TITLE
docs: Fixing broken link to projen.io

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ This document describes how to set up a development environment and submit your 
 * Ensure [Node.js ≥ 18.12.0](https://nodejs.org/download/release/latest-v18.x/) is installed
   * We recommend using a version in [Active LTS](https://nodejs.org/en/about/previous-releases)
  
-This project uses [Projen](https://projen.io/releases.html).
+This project uses [Projen](https://projen.io).
 
 Once you have all the required dependencies installed, you can fork this repo, then:
 


### PR DESCRIPTION
### Issue # (if applicable)


### Reason for this change

Seems like https://projen.io/releases.html is no longer valid, so changing to the landing site 

### Description of changes

Minor fix in the docs

### Description of how you validated changes

Followed the link

### Checklist

- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/sbt-aws/blob/main/CONTRIBUTING.md)
- [x] I have updated the relevant documentation (if applicable).

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the project license.*
