### PR TITLE
feat: Added support to configure advancedSecurityMode on ControlPlane

### DIFF
--- a/API.md
+++ b/API.md
@@ -3860,6 +3860,7 @@ const cognitoAuthProps: CognitoAuthProps = { ... }
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
 | <code><a href="#@cdklabs/sbt-aws.CognitoAuthProps.property.controlPlaneCallbackURL">controlPlaneCallbackURL</a></code> | <code>string</code> | The callback URL for the control plane. |
+| <code><a href="#@cdklabs/sbt-aws.CognitoAuthProps.property.enableAdvancedSecurityMode">enableAdvancedSecurityMode</a></code> | <code>boolean</code> | Whether or not to enforce advanced security mode. |
 | <code><a href="#@cdklabs/sbt-aws.CognitoAuthProps.property.setAPIGWScopes">setAPIGWScopes</a></code> | <code>boolean</code> | Whether or not to specify scopes for validation at the API GW. |
 
 ---
@@ -3874,6 +3875,21 @@ public readonly controlPlaneCallbackURL: string;
 - *Default:* 'http://localhost'
 
 The callback URL for the control plane.
+
+---
+
+##### `enableAdvancedSecurityMode`<sup>Optional</sup> <a name="enableAdvancedSecurityMode" id="@cdklabs/sbt-aws.CognitoAuthProps.property.enableAdvancedSecurityMode"></a>
+
+```typescript
+public readonly enableAdvancedSecurityMode: boolean;
+```
+
+- *Type:* boolean
+- *Default:* true
+
+Whether or not to enforce advanced security mode.
+
+Can be used for testing purposes.
 
 ---
 

--- a/docs/public/README.md
+++ b/docs/public/README.md
@@ -104,7 +104,8 @@ export class ControlPlaneStack extends Stack {
   constructor(scope: Construct, id: string, props?: any) {
     super(scope, id, props);
     const cognitoAuth = new sbt.CognitoAuth(this, 'CognitoAuth', {
-      // Avoid checking scopes for API endpoints. Done only for testing purposes.
+      // Avoid disabling advanced security mode and checking scopes for API endpoints. Done only for testing purposes.
+      enableAdvancedSecurityMode: false,
       setAPIGWScopes: false,
     });
 
@@ -440,13 +441,8 @@ export tenantStatus="created"
 echo "done!"
 `,
       environmentStringVariablesFromIncomingEvent: ['tenantId', 'tier'],
-      environmentVariablesToOutgoingEvent: { 
-        tenantData: [
-          'tenantS3Bucket',
-          'tenantConfig',
-          'someOtherVariable', 
-          'tenantStatus'
-     ],
+      environmentVariablesToOutgoingEvent: {
+        tenantData: ['tenantS3Bucket', 'tenantConfig', 'someOtherVariable', 'tenantStatus'],
         tenantRegistrationData: ['registrationStatus'],
       },
       scriptEnvironmentVariables: {
@@ -719,6 +715,7 @@ The application plane emits this event upon successful completion of tenant offb
   }
 }
 ```
+
 ## Design tenets
 
 - **A templated model for producing best practices SaaS applications** - SBT strives to provide a mental model, and a foundational implementation from which almost any SaaS application can be built

--- a/docs/public/README.md
+++ b/docs/public/README.md
@@ -104,9 +104,8 @@ export class ControlPlaneStack extends Stack {
   constructor(scope: Construct, id: string, props?: any) {
     super(scope, id, props);
     const cognitoAuth = new sbt.CognitoAuth(this, 'CognitoAuth', {
-      // Avoid disabling advanced security mode and checking scopes for API endpoints. Done only for testing purposes.
-      enableAdvancedSecurityMode: false,
-      setAPIGWScopes: false,
+      enableAdvancedSecurityMode: false, // only for testing purposes!
+      setAPIGWScopes: false, // only for testing purposes!
     });
 
     const controlPlane = new sbt.ControlPlane(this, 'ControlPlane', {

--- a/src/control-plane/auth/cognito-auth.ts
+++ b/src/control-plane/auth/cognito-auth.ts
@@ -30,6 +30,13 @@ export interface CognitoAuthProps {
   readonly controlPlaneCallbackURL?: string;
 
   /**
+   * Whether or not to enforce advanced security mode.
+   * Can be used for testing purposes.
+   * @default true
+   */
+  readonly enableAdvancedSecurityMode?: boolean;
+
+  /**
    * Whether or not to specify scopes for validation at the API GW.
    * Can be used for testing purposes.
    * @default true
@@ -248,7 +255,10 @@ export class CognitoAuth extends Construct implements IAuth {
       customAttributes: {
         userRole: new cognito.StringAttribute({ mutable: true, minLen: 1, maxLen: 256 }),
       },
-      advancedSecurityMode: cognito.AdvancedSecurityMode.ENFORCED,
+      advancedSecurityMode:
+        props?.enableAdvancedSecurityMode != false
+          ? cognito.AdvancedSecurityMode.ENFORCED
+          : cognito.AdvancedSecurityMode.OFF,
     });
 
     NagSuppressions.addResourceSuppressions(this.userPool, [

--- a/src/control-plane/auth/cognito-auth.ts
+++ b/src/control-plane/auth/cognito-auth.ts
@@ -256,9 +256,9 @@ export class CognitoAuth extends Construct implements IAuth {
         userRole: new cognito.StringAttribute({ mutable: true, minLen: 1, maxLen: 256 }),
       },
       advancedSecurityMode:
-        props?.enableAdvancedSecurityMode != false
-          ? cognito.AdvancedSecurityMode.ENFORCED
-          : cognito.AdvancedSecurityMode.OFF,
+        props?.enableAdvancedSecurityMode == false
+          ? cognito.AdvancedSecurityMode.OFF
+          : cognito.AdvancedSecurityMode.ENFORCED,
     });
 
     NagSuppressions.addResourceSuppressions(this.userPool, [

--- a/src/control-plane/integ.default.ts
+++ b/src/control-plane/integ.default.ts
@@ -17,6 +17,7 @@ export class IntegStack extends cdk.Stack {
     super(scope, id, props);
 
     const cognitoAuth = new sbt.CognitoAuth(this, 'CognitoAuth', {
+      enableAdvancedSecurityMode: false, // only for testing purposes!
       setAPIGWScopes: false, // only for testing purposes!
     });
 

--- a/website/docs/tutorials/tutorial-basics/create-control-plane.md
+++ b/website/docs/tutorials/tutorial-basics/create-control-plane.md
@@ -22,9 +22,8 @@ export class ControlPlaneStack extends Stack {
   constructor(scope: Construct, id: string, props?: any) {
     super(scope, id, props);
     const cognitoAuth = new sbt.CognitoAuth(this, 'CognitoAuth', {
-      // Avoid disabling advanced security mode and checking scopes for API endpoints. Done only for testing purposes.
-      enableAdvancedSecurityMode: false,
-      setAPIGWScopes: false,
+      enableAdvancedSecurityMode: false, // only for testing purposes!
+      setAPIGWScopes: false, // only for testing purposes!
     });
 
     const controlPlane = new sbt.ControlPlane(this, 'ControlPlane', {

--- a/website/docs/tutorials/tutorial-basics/create-control-plane.md
+++ b/website/docs/tutorials/tutorial-basics/create-control-plane.md
@@ -22,7 +22,8 @@ export class ControlPlaneStack extends Stack {
   constructor(scope: Construct, id: string, props?: any) {
     super(scope, id, props);
     const cognitoAuth = new sbt.CognitoAuth(this, 'CognitoAuth', {
-      // Avoid checking scopes for API endpoints. Done only for testing purposes.
+      // Avoid disabling advanced security mode and checking scopes for API endpoints. Done only for testing purposes.
+      enableAdvancedSecurityMode: false,
       setAPIGWScopes: false,
     });
 


### PR DESCRIPTION
### Issue #[141](https://github.com/awslabs/sbt-aws/issues/141)

Closes #141.

### Reason for this change

For testing purposes, this feature allows it not generate additional costs from Cognito.

### Description of changes

I created a new parameter `enableAdvancedSecurityMode` in the CognitoAuthProps interface to define whether the advancedSecurityMode attribute of the Cognito User Pool will be enabled or not. This parameter is optional and its default value is true.

### Description of how you validated changes

I ran these commands and the tests passed successfully:
`npm install`
`npm run build`

### Checklist

- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/sbt-aws/blob/main/CONTRIBUTING.md)
- [x] I have updated the relevant documentation (if applicable).

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the project license.*
