### PR TITLE
feat: Adding a tenantRegistrationId column to tenantManagementTable

### DIFF
--- a/docs/public/README.md
+++ b/docs/public/README.md
@@ -644,7 +644,8 @@ The control plane emits this event any time it onboards a new tenant. This event
     "tenantName": "tenant$RANDOM",
     "email": "tenant@example.com",
     "tier": "basic",
-    "tenantStatus": "In progress"
+    "tenantStatus": "In progress",
+    "tenantRegistrationId": "guid string"
   }
 }
 ```

--- a/resources/functions/tenant-registrations/index.py
+++ b/resources/functions/tenant-registrations/index.py
@@ -46,6 +46,7 @@ def create_tenant_registration():
     json_body = app.current_event.json_body
     tenant_registration_id = str(uuid.uuid4())
     tenant_data = json_body.get("tenantData", {})
+    tenant_data["tenantRegistrationId"] = tenant_registration_id
     tenant_registration_data = json_body.get("tenantRegistrationData", {})
 
     # Create tenant registration
@@ -76,7 +77,7 @@ def create_tenant_registration():
         json.dumps(
             tenant_registration_data
             | tenant_data
-            | {"tenantId": tenant_id, "tenantRegistrationId": tenant_registration_id}
+            | {"tenantId": tenant_id}
         ),
         onboarding_detail_type,
     )


### PR DESCRIPTION
### Issue # (if applicable)

Closes #<issue number here>.

### Reason for this change

- Tenant management table lacks tenantRegistrationId
- SaaS provider UI (Admin) should display tenant information
- Tenant removal API call from UI is hindered without tenantRegistrationId

### Description of changes

The create_tenant_registration of Tenant Registration Lambda.
- Add tenantRegistrationId value to tenant_data dictionary
- Removed tenantRegistrationId from __create_control_plane_event

### Description of how you validated changes
- Tenant Removal test from UI.

<!--Have you added any unit tests and/or integration tests?-->

### Checklist

- [ ] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/sbt-aws/blob/main/CONTRIBUTING.md)
- [ ] I have updated the relevant documentation (if applicable).

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the project license.*
