### PR TITLE
fix: updated contributing instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,9 +35,8 @@ Please consult the issues and discussions section of the SBT repo for good first
 2. Make sure existing (and new) tests pass successfully by running `npm run test`
 3. Run `npm run build` to compile
 4. Go to the root of the project. Then, deploy the CDK stack using the following:
-   - For `control-plane`: `CDK_PARAM_SYSTEM_ADMIN_EMAIL="test@example.com" npx cdk deploy --app='./lib/control-plane/integ.default.js'`
-   - Once the control plane has been deployed, obtain the ARN of the newly deployed event bus [here](https://us-east-1.console.aws.amazon.com/events/home?region=us-east-1#/eventbuses)
-   - For `core-app-plane`: `CDK_PARAM_EVENT_BUS_ARN="<EVENT BUS ARN HERE>" npx cdk deploy --app='./lib/core-app-plane/integ.default.js'`
+   - For `control-plane`: `CDK_PARAM_SYSTEM_ADMIN_EMAIL="test@example.com" npx cdk deploy --app='./lib/control-plane/integ.default.js'` 
+   - For `core-app-plane`: `CDK_PARAM_EVENT_BUS_ARN=$(aws cloudformation describe-stacks --stack-name "ControlPlane-integ"  --query "Stacks[0].Outputs[?OutputKey=='eventBridgeArn'].OutputValue" --output text) npx cdk deploy --app='./lib/core-app-plane/integ.default.js'`
 5. Test out the new feature(s) and redeploy as needed
 6. Write tests for any changed code and commit
 7. Create a PR

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,12 +32,12 @@ Please consult the issues and discussions section of the SBT repo for good first
 ## Development
 
 1. Make desired changes
-1. Make sure existing (and new) tests pass successfully by running `npm run test`
-1. Run `npm run build` to compile
-1. Go to the root of the project. Then, deploy the CDK stack using the following:
-   - For `core-app-plane`: `npx cdk deploy --app='./lib/core-app-plane/integ.default.js'`
+2. Make sure existing (and new) tests pass successfully by running `npm run test`
+3. Run `npm run build` to compile
+4. Go to the root of the project. Then, deploy the CDK stack using the following:
    - For `control-plane`: `CDK_PARAM_SYSTEM_ADMIN_EMAIL="test@example.com" npx cdk deploy --app='./lib/control-plane/integ.default.js'`
-1. Test out the new feature(s) and redeploy as needed
-1. Write tests for any changed code and commit
-1. Create a PR.
-
+   - Once the control plane has been deployed, obtain the ARN of the newly deployed event bus [here](https://us-east-1.console.aws.amazon.com/events/home?region=us-east-1#/eventbuses)
+   - For `core-app-plane`: `CDK_PARAM_EVENT_BUS_ARN="<EVENT BUS ARN HERE>" npx cdk deploy --app='./lib/core-app-plane/integ.default.js'`
+5. Test out the new feature(s) and redeploy as needed
+6. Write tests for any changed code and commit
+7. Create a PR


### PR DESCRIPTION
…e ARN to connect the two planes

### Issue # (if applicable)

Closes #<issue number here>.

### Reason for this change

CONTRIBUTING.md does not instruct users to use the Eventbridge ARN from the control plane when deploying the core app plane, resulting in the deployment of the two planes without any communication. This will also result in the failure of the test scripts when provisioning and deprovisioning tenants, as there is no prior instruction to connect the two planes when deploying. 

### Description of changes

Edited CONTRIBUTING.md 

### Description of how you validated changes

N/A

### Checklist

- [X] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/sbt-aws/blob/main/CONTRIBUTING.md)
- [X] I have updated the relevant documentation (if applicable).

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the project license.*
