### PR TITLE
ci: update run-tests workflow to trigger on PRs to main branch instea…

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -2,8 +2,9 @@
 
 name: run-tests
 on:
-  schedule:
-    - cron: 0 6 * * *
+  pull_request:
+    branches:
+      - main
 jobs:
   run-tests:
     runs-on: ubuntu-22.04

--- a/projenrc/run-tests-workflow.ts
+++ b/projenrc/run-tests-workflow.ts
@@ -18,9 +18,9 @@ export function runTestsWorkflow(project: AwsCdkConstructLibrary) {
   const runTests = project.github?.addWorkflow('run-tests');
   if (runTests) {
     runTests.on({
-      schedule: [
-        { cron: '0 6 * * *' }, // Runs at midnight Mountain Time (UTC-6) every day
-      ],
+      pullRequest: {
+        branches: ['main'],
+      },
     });
 
     runTests.addJobs({


### PR DESCRIPTION
…d of schedule

Changed the GitHub workflow trigger from nightly schedule to pull requests against the main branch. This ensures tests are run when changes are proposed, rather than on a fixed schedule.

### Issue # (if applicable)

Closes #<issue number here>.

### Reason for this change

<!--What is the bug or use case behind this change?-->

### Description of changes

<!--What code changes did you make? Have you made any important design decisions?-->

### Description of how you validated changes

<!--Have you added any unit tests and/or integration tests?-->

### Checklist

- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/sbt-aws/blob/main/CONTRIBUTING.md)
- [x] I have updated the relevant documentation (if applicable).

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the project license.*
