### PR TITLE
feat: add workflow_dispatch trigger to run-tests workflow

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -5,6 +5,7 @@ on:
   pull_request:
     branches:
       - main
+  workflow_dispatch: {}
 jobs:
   run-tests:
     runs-on: ubuntu-22.04

--- a/projenrc/run-tests-workflow.ts
+++ b/projenrc/run-tests-workflow.ts
@@ -21,6 +21,7 @@ export function runTestsWorkflow(project: AwsCdkConstructLibrary) {
       pullRequest: {
         branches: ['main'],
       },
+      workflowDispatch: {}, // Add workflow_dispatch trigger to allow manual runs
     });
 
     runTests.addJobs({


### PR DESCRIPTION
This change adds the workflow_dispatch event trigger to the run-tests GitHub Actions workflow, allowing repository administrators to manually trigger the workflow from the GitHub UI. This is particularly useful for testing workflows that require access to repository secrets, which are not available when workflows are triggered from fork pull requests.

### Issue # (if applicable)

Closes #<issue number here>.

### Reason for this change

<!--What is the bug or use case behind this change?-->

### Description of changes

<!--What code changes did you make? Have you made any important design decisions?-->

### Description of how you validated changes

<!--Have you added any unit tests and/or integration tests?-->

### Checklist

- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/sbt-aws/blob/main/CONTRIBUTING.md)
- [x] I have updated the relevant documentation (if applicable).

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the project license.*
