### PR TITLE
fix: Make run-tests job always depend on build job

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch: {}
 jobs:
   run-tests:
-    needs: ${{ github.event_name == 'pull_request' && 'build' || '' }}
+    needs: build
     runs-on: ubuntu-24.04-arm
     permissions:
       id-token: write

--- a/projenrc/run-tests-workflow.ts
+++ b/projenrc/run-tests-workflow.ts
@@ -48,7 +48,7 @@ export function runTestsWorkflow(
           contents: JobPermission.READ,
         },
         // Make dependency conditional - only for PR events, not for manual workflow_dispatch
-        needs: [`\${{ github.event_name == 'pull_request' && '${buildJobId}' || '' }}`],
+        needs: [buildJobId],
         // Run if either:
         // 1. It's a manual workflow dispatch OR
         // 2. It's a PR where build succeeded AND PR is from the same repo (not a fork)


### PR DESCRIPTION
### Issue # (if applicable)

Closes #<issue number here>.

### Reason for this change

<!--What is the bug or use case behind this change?-->

### Description of changes

<!--What code changes did you make? Have you made any important design decisions?-->

### Description of how you validated changes

<!--Have you added any unit tests and/or integration tests?-->

### Checklist

- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/sbt-aws/blob/main/CONTRIBUTING.md)
- [x] I have updated the relevant documentation (if applicable).

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the project license.*
