### PR TITLE
feat: Extend ScriptJob CodeBuild Project props

### DIFF
--- a/API.md
+++ b/API.md
@@ -4993,6 +4993,7 @@ const scriptJobProps: ScriptJobProps = { ... }
 | <code><a href="#@cdklabs/sbt-aws.ScriptJobProps.property.environmentStringVariablesFromIncomingEvent">environmentStringVariablesFromIncomingEvent</a></code> | <code>string[]</code> | The environment variables to import into the ScriptJob from event details field. |
 | <code><a href="#@cdklabs/sbt-aws.ScriptJobProps.property.environmentVariablesToOutgoingEvent">environmentVariablesToOutgoingEvent</a></code> | <code><a href="#@cdklabs/sbt-aws.EnvironmentVariablesToOutgoingEventProps">EnvironmentVariablesToOutgoingEventProps</a></code> | The environment variables to export into the outgoing event once the ScriptJob has finished. |
 | <code><a href="#@cdklabs/sbt-aws.ScriptJobProps.property.postScript">postScript</a></code> | <code>string</code> | The bash script to run after the main script has completed. |
+| <code><a href="#@cdklabs/sbt-aws.ScriptJobProps.property.projectProps">projectProps</a></code> | <code>aws-cdk-lib.aws_codebuild.ProjectProps</code> | Allows customisation of the CodeBuild project. |
 | <code><a href="#@cdklabs/sbt-aws.ScriptJobProps.property.scriptEnvironmentVariables">scriptEnvironmentVariables</a></code> | <code>{[ key: string ]: string}</code> | The variables to pass into the codebuild ScriptJob. |
 | <code><a href="#@cdklabs/sbt-aws.ScriptJobProps.property.source">source</a></code> | <code>aws-cdk-lib.aws_codebuild.Source</code> | The Source to use when executing the ScriptJob. |
 
@@ -5161,6 +5162,21 @@ The bash script to run after the main script has completed.
 
 ---
 
+##### `projectProps`<sup>Optional</sup> <a name="projectProps" id="@cdklabs/sbt-aws.ScriptJobProps.property.projectProps"></a>
+
+```typescript
+public readonly projectProps: ProjectProps;
+```
+
+- *Type:* aws-cdk-lib.aws_codebuild.ProjectProps
+
+Allows customisation of the CodeBuild project.
+
+This will overwrite any of the defaults
+so be aware of that.
+
+---
+
 ##### `scriptEnvironmentVariables`<sup>Optional</sup> <a name="scriptEnvironmentVariables" id="@cdklabs/sbt-aws.ScriptJobProps.property.scriptEnvironmentVariables"></a>
 
 ```typescript
@@ -5316,6 +5332,7 @@ const tenantLifecycleScriptJobProps: TenantLifecycleScriptJobProps = { ... }
 | <code><a href="#@cdklabs/sbt-aws.TenantLifecycleScriptJobProps.property.environmentStringVariablesFromIncomingEvent">environmentStringVariablesFromIncomingEvent</a></code> | <code>string[]</code> | The environment variables to import into the ScriptJob from event details field. |
 | <code><a href="#@cdklabs/sbt-aws.TenantLifecycleScriptJobProps.property.environmentVariablesToOutgoingEvent">environmentVariablesToOutgoingEvent</a></code> | <code><a href="#@cdklabs/sbt-aws.EnvironmentVariablesToOutgoingEventProps">EnvironmentVariablesToOutgoingEventProps</a></code> | The environment variables to export into the outgoing event once the ScriptJob has finished. |
 | <code><a href="#@cdklabs/sbt-aws.TenantLifecycleScriptJobProps.property.postScript">postScript</a></code> | <code>string</code> | The bash script to run after the main script has completed. |
+| <code><a href="#@cdklabs/sbt-aws.TenantLifecycleScriptJobProps.property.projectProps">projectProps</a></code> | <code>aws-cdk-lib.aws_codebuild.ProjectProps</code> | Allows customisation of the CodeBuild project. |
 | <code><a href="#@cdklabs/sbt-aws.TenantLifecycleScriptJobProps.property.scriptEnvironmentVariables">scriptEnvironmentVariables</a></code> | <code>{[ key: string ]: string}</code> | The variables to pass into the codebuild ScriptJob. |
 | <code><a href="#@cdklabs/sbt-aws.TenantLifecycleScriptJobProps.property.source">source</a></code> | <code>aws-cdk-lib.aws_codebuild.Source</code> | The Source to use when executing the ScriptJob. |
 
@@ -5421,6 +5438,21 @@ public readonly postScript: string;
 - *Type:* string
 
 The bash script to run after the main script has completed.
+
+---
+
+##### `projectProps`<sup>Optional</sup> <a name="projectProps" id="@cdklabs/sbt-aws.TenantLifecycleScriptJobProps.property.projectProps"></a>
+
+```typescript
+public readonly projectProps: ProjectProps;
+```
+
+- *Type:* aws-cdk-lib.aws_codebuild.ProjectProps
+
+Allows customisation of the CodeBuild project.
+
+This will overwrite any of the defaults
+so be aware of that.
 
 ---
 

--- a/src/core-app-plane/integ.default.ts
+++ b/src/core-app-plane/integ.default.ts
@@ -12,6 +12,7 @@
  */
 
 import * as cdk from 'aws-cdk-lib';
+import { ComputeType, LinuxArmLambdaBuildImage, ProjectProps } from 'aws-cdk-lib/aws-codebuild';
 import { CfnRule, EventBus, Rule } from 'aws-cdk-lib/aws-events';
 import { Effect, PolicyDocument, PolicyStatement } from 'aws-cdk-lib/aws-iam';
 import { LogGroup, RetentionDays } from 'aws-cdk-lib/aws-logs';
@@ -19,6 +20,7 @@ import { AwsSolutionsChecks, NagSuppressions } from 'cdk-nag';
 import * as sbt from '.';
 import { DestroyPolicySetter } from '../cdk-aspect/destroy-policy-setter';
 import { EventManager } from '../utils';
+//import { ComputeType, LinuxArmLambdaBuildImage, ProjectProps } from 'aws-cdk-lib/aws-codebuild';
 
 export interface IntegStackProps extends cdk.StackProps {
   eventBusArn?: string;
@@ -38,6 +40,18 @@ export class IntegStack extends cdk.Stack {
     } else {
       eventManager = new EventManager(this, 'EventManager');
     }
+
+    const projectProps: ProjectProps = {
+      environment: {
+        environmentVariables: {
+          VARIABLE_NAME: {
+            value: 'someValue',
+          },
+        },
+        buildImage: LinuxArmLambdaBuildImage.AMAZON_LINUX_2023_NODE_20,
+        computeType: ComputeType.LAMBDA_2GB,
+      },
+    };
 
     const provisioningScriptJobProps: sbt.TenantLifecycleScriptJobProps = {
       permissions: new PolicyDocument({
@@ -111,6 +125,7 @@ echo "done!"
         TEST: 'test',
       },
       eventManager: eventManager,
+      projectProps: projectProps,
     };
 
     const deprovisioningScriptJobProps: sbt.TenantLifecycleScriptJobProps = {
@@ -143,6 +158,7 @@ echo "done!"
         tenantRegistrationData: ['registrationStatus'],
       },
       eventManager: eventManager,
+      projectProps: projectProps,
     };
 
     const provisioningJobScript: sbt.ProvisioningScriptJob = new sbt.ProvisioningScriptJob(

--- a/src/core-app-plane/integ.default.ts
+++ b/src/core-app-plane/integ.default.ts
@@ -20,7 +20,6 @@ import { AwsSolutionsChecks, NagSuppressions } from 'cdk-nag';
 import * as sbt from '.';
 import { DestroyPolicySetter } from '../cdk-aspect/destroy-policy-setter';
 import { EventManager } from '../utils';
-//import { ComputeType, LinuxArmLambdaBuildImage, ProjectProps } from 'aws-cdk-lib/aws-codebuild';
 
 export interface IntegStackProps extends cdk.StackProps {
   eventBusArn?: string;

--- a/src/core-app-plane/script-job.ts
+++ b/src/core-app-plane/script-job.ts
@@ -156,6 +156,12 @@ export interface ScriptJobProps {
    * the Control Plane and other components.
    */
   readonly eventManager: IEventManager;
+
+  /**
+   * Allows customisation of the CodeBuild project. This will overwrite any of the defaults
+   * so be aware of that.
+   */
+  readonly projectProps?: codebuild.ProjectProps;
 }
 
 /**
@@ -283,6 +289,7 @@ export class ScriptJob extends Construct {
           },
         },
       }),
+      ...props.projectProps,
     });
 
     NagSuppressions.addResourceSuppressions(codebuildProject, [

--- a/src/core-app-plane/tenant-lifecycle-script-jobs.ts
+++ b/src/core-app-plane/tenant-lifecycle-script-jobs.ts
@@ -11,7 +11,7 @@
  *  and limitations under the License.
  */
 
-import { IBuildImage, Source } from 'aws-cdk-lib/aws-codebuild';
+import { IBuildImage, ProjectProps, Source } from 'aws-cdk-lib/aws-codebuild';
 import * as iam from 'aws-cdk-lib/aws-iam';
 import { Construct } from 'constructs';
 import { EnvironmentVariablesToOutgoingEventProps, ScriptJob, ScriptJobProps } from './script-job';
@@ -81,6 +81,12 @@ export interface TenantLifecycleScriptJobProps {
    * the Control Plane and other components.
    */
   readonly eventManager: IEventManager;
+
+  /**
+   * Allows customisation of the CodeBuild project. This will overwrite any of the defaults
+   * so be aware of that.
+   */
+  readonly projectProps?: ProjectProps;
 }
 
 /**


### PR DESCRIPTION
### Issue # (if applicable)

Closes #<issue number here>.

### Reason for this change

ScriptJob (and by extension ProvisioningScriptJob and DeProvisioningScriptJob) don't have a way to modify the CodeBuild project properties. For example, one may wish to use Lambda ARM compute resources, or optimise for build performance.

### Description of changes

Added CodeBuild ProjectProps as a optional input for ScriptJobProps and TenantLifecycleScriptJobProps. These will overwrite defaults so discretion is advised. In general, if you're playing in here then you should understand what you're doing. I feel the flexibility is justified.

### Description of how you validated changes

Added extra properties to the integration test for the core app. It deploys with Lambda ARM which is non-default.

### Checklist

- [X] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/sbt-aws/blob/main/CONTRIBUTING.md)
- [X] I have updated the relevant documentation (if applicable).

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the project license.*
