### PR TITLE
fix: add sandbox attribute to YouTube iframe for security

### DIFF
--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -15,7 +15,13 @@ function VideoPlayer({ url }) {
         url={url} 
         controls
         width="100%"
-        // height="100%"
+        config={{
+          youtube: {
+            playerVars: {
+              sandbox: 'allow-scripts allow-same-origin allow-presentation'
+            }
+          }
+        }}
       />
     </div>
   );


### PR DESCRIPTION
- Added sandbox restrictions to ReactPlayer YouTube config
- Prevents potentially malicious code execution in embedded videos
- Maintains video functionality with allow-scripts, allow-same-origin, allow-presentation

### Issue # (if applicable)

Closes #<issue number here>.

### Reason for this change

<!--What is the bug or use case behind this change?-->

### Description of changes

<!--What code changes did you make? Have you made any important design decisions?-->

### Description of how you validated changes

<!--Have you added any unit tests and/or integration tests?-->

### Checklist

- [ ] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/sbt-aws/blob/main/CONTRIBUTING.md)
- [ ] I have updated the relevant documentation (if applicable).

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the project license.*
