### PR TITLE
fix: upgrade jQuery to 3.7.1 in sample registration page

### DIFF
--- a/resources/aws-marketplace/static/index.html
+++ b/resources/aws-marketplace/static/index.html
@@ -34,8 +34,8 @@
     <!-- Optional JavaScript -->
     <!-- jQuery first, then Popper.js, then Bootstrap JS -->
     <script
-      src="https://code.jquery.com/jquery-3.3.1.slim.min.js"
-      integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo"
+      src="https://code.jquery.com/jquery-3.7.1.slim.min.js"
+      integrity="sha384-5AkRS45j4ukf+JbWAfHL8P4onPA9p0KwwP7pUdjSQA3ss9edbJUJc/XcYAiheSSz"
       crossorigin="anonymous"
     ></script>
     <script


### PR DESCRIPTION
### Issue # (if applicable)

N/A — security remediation.

### Reason for this change

The sample AWS Marketplace registration page (`resources/aws-marketplace/static/index.html`) loads jQuery 3.3.1 (slim) from the jQuery CDN. jQuery versions below 3.5.0 are affected by known cross-site scripting vulnerabilities ([CVE-2020-11022](https://nvd.nist.gov/vuln/detail/CVE-2020-11022), [CVE-2020-11023](https://nvd.nist.gov/vuln/detail/CVE-2020-11023)) in `jQuery.htmlPrefilter` when passing untrusted HTML to DOM manipulation methods.

### Description of changes

- Upgraded the CDN-loaded jQuery slim build from 3.3.1 to 3.7.1 (latest 3.x release).
- Updated the Subresource Integrity (SRI) `integrity` hash to match the new file (sha384, verified against the file served by code.jquery.com).

No application code changes were needed: the page's dynamic script (`resources/aws-marketplace/dynamic/script.js`) uses vanilla DOM APIs and `fetch` — jQuery is only present as a Bootstrap 4 peer dependency, and the 3.x line is API-compatible for Bootstrap's usage.

### Description of how you validated changes

- Verified the SRI hash by downloading `jquery-3.7.1.slim.min.js` from code.jquery.com and computing the sha384 digest.
- Ran the jest suite; results match the baseline on `main` in my environment (remaining failures are pre-existing and unrelated — Docker-dependent PythonFunction bundling tests). This change only touches a static HTML asset deployed via `BucketDeployment`, which is not covered by unit tests.

### Checklist

- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/sbt-aws/blob/main/CONTRIBUTING.md)
- [x] I have updated the relevant documentation (if applicable).

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the project license.*