### PR TITLE
fix: remove DOM-based XSS sinks from sample registration page script

### DIFF
--- a/resources/aws-marketplace/dynamic/script.js
+++ b/resources/aws-marketplace/dynamic/script.js
@@ -52,24 +52,44 @@ const toggleSpinnerAndText = (button, showSpinner) => {
 
   if (showSpinner) {
     button.disabled = true;
-    button.innerHTML = '';
-    button.appendChild(spinner);
+    button.replaceChildren(spinner);
   } else {
     button.disabled = false;
-    button.innerHTML = 'Register';
+    button.textContent = 'Register';
   }
 };
 
-const showAlert = (cssClass, message) => {
-  const html = `
-    <div class="alert alert-${cssClass} alert-dismissible" role="alert">
-        <strong>${message}</strong>
-        <button class="close" type="button" data-dismiss="alert" aria-label="Close">
-            <span aria-hidden="true">×</span>
-        </button>
-    </div>`;
+// Only allow known Bootstrap contextual classes to reach the DOM.
+const ALLOWED_ALERT_CLASSES = ['primary', 'danger'];
 
-  document.querySelector('#alert').innerHTML += html;
+const showAlert = (cssClass, message) => {
+  if (!ALLOWED_ALERT_CLASSES.includes(cssClass)) {
+    cssClass = 'primary';
+  }
+
+  const alertDiv = document.createElement('div');
+  alertDiv.className = `alert alert-${cssClass} alert-dismissible`;
+  alertDiv.setAttribute('role', 'alert');
+
+  // Render the message as text, never as HTML, to prevent DOM-based XSS.
+  const strong = document.createElement('strong');
+  strong.textContent = message;
+
+  const closeButton = document.createElement('button');
+  closeButton.className = 'close';
+  closeButton.type = 'button';
+  closeButton.setAttribute('data-dismiss', 'alert');
+  closeButton.setAttribute('aria-label', 'Close');
+
+  const closeIcon = document.createElement('span');
+  closeIcon.setAttribute('aria-hidden', 'true');
+  closeIcon.textContent = '×';
+  closeButton.appendChild(closeIcon);
+
+  alertDiv.appendChild(strong);
+  alertDiv.appendChild(closeButton);
+
+  document.querySelector('#alert').appendChild(alertDiv);
 };
 
 const getUrlParameter = (name) => {


### PR DESCRIPTION
### Issue # (if applicable)

N/A — security remediation.

### Reason for this change

The sample AWS Marketplace registration page script (`resources/aws-marketplace/dynamic/script.js`) built its Bootstrap alert by interpolating values into an HTML string and assigning it with `innerHTML`:

- The `message` shown after form submission comes from the `POST /subscriber` API response body. Any attacker-influenced content in that message would be parsed as HTML in the victim's browser — a DOM-based XSS sink.
- The `cssClass` parameter was also interpolated into the class attribute unvalidated.
- `toggleSpinnerAndText` used two more `innerHTML` writes (constant values today, but the same sink pattern).

### Description of changes

- `showAlert` now builds the alert with `document.createElement` and sets the message via `textContent`, so it is always rendered as text and never parsed as HTML. The rendered markup is identical to the previous Bootstrap 4 alert (`alert alert-<class> alert-dismissible` with a `data-dismiss` close button).
- The alert contextual class is validated against an allowlist (`primary`, `danger` — the only values used by the page), defaulting to `primary`.
- `toggleSpinnerAndText` uses `Element.replaceChildren()` and `textContent` instead of `innerHTML`.
- As a side effect, appending a new alert node (instead of `innerHTML +=`) no longer re-parses existing alerts, which previously detached any state/listeners on them.

No framework or dependency changes; `replaceChildren` is supported in all evergreen browsers (Chrome/Edge 86+, Firefox 78+, Safari 14+).

### Description of how you validated changes

- `node --check` passes on the modified script.
- Swept the repo for remaining DOM XSS sinks (`innerHTML`, `outerHTML`, `insertAdjacentHTML`, `document.write`, `eval`, `new Function`, jQuery `.html()`): none remain in shipped client-side assets.
- This file is a deploy-time-substituted static asset (`DeployTimeSubstitutedFile`) with no unit-test coverage; the existing jest suite is unaffected.

### Checklist

- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/awslabs/sbt-aws/blob/main/CONTRIBUTING.md)
- [x] I have updated the relevant documentation (if applicable).

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the project license.*