### PR TITLE
fix(website): disable Docusaurus baseUrlIssueBanner to remove DOM-based XSS sink

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -20,6 +20,12 @@ const config: Config = {
    onBrokenLinks: 'throw',
    onBrokenMarkdownLinks: 'warn',
 
+   // Disable the base-URL issue banner. It injects an inline script that writes
+   // `window.location.pathname` into the DOM via innerHTML, which AppSec/ACAT
+   // flags as a DOM-based XSS sink. Disabling it removes that inline script from
+   // every generated page (also required for strict Content-Security-Policy).
+   baseUrlIssueBanner: false,
+
   // Even if you don't use internationalization, you can use this field to set
   // useful metadata like html lang. For example, if your site is Chinese, you
   // may want to replace "en" with "zh-Hans".


### PR DESCRIPTION
## Why

AWS AppSec/ACAT reports a **DOM-based Cross-site Scripting** finding on the published documentation site (`gh-pages` branch, `index.html`). The flagged sink is Docusaurus's *generated* base-URL issue banner — an inline `<script>` that writes `window.location.pathname` into the DOM via `innerHTML`:

```js
function insertBanner(){var n=document.createElement("div");...n.innerHTML='...';...
  e.innerHTML=o /* o derived from window.location.pathname */}
```

This banner is emitted into **every** generated page because Docusaurus's top-level `baseUrlIssueBanner` config option defaults to `true`. It is framework-generated output, so editing `gh-pages` directly would be overwritten on the next deploy — the fix must live in the site config.

## What

Set `baseUrlIssueBanner: false` in `website/docusaurus.config.ts`. This removes the inline banner script from all generated pages. Docusaurus [documents](https://docusaurus.io/docs/api/docusaurus-config#baseUrlIssueBanner) this option as also being the recommended setting for sites with a strict Content-Security-Policy, since the banner requires inline JS.

## Verification

Ran `npm run build` and inspected the output:

- **0 of 27** generated HTML pages contain the `insertBanner` / `__docusaurus-base-url-issue-banner` inline script.
- `build/index.html` contains **0** `innerHTML` occurrences (previously the sink was on line 6).

The banner is a developer-convenience diagnostic for misconfigured `baseUrl`; the site's `baseUrl` (`/sbt-aws/`) is correct, so removing it has no functional impact.


*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the project license.*
