### PR TITLE
ci: pin third-party GitHub Actions to commit SHAs (projen-aware)

### DIFF
--- a/.github/workflows/pull-request-lint.yml
+++ b/.github/workflows/pull-request-lint.yml
@@ -19,7 +19,7 @@ jobs:
       pull-requests: write
     if: (github.event_name == 'pull_request' || github.event_name == 'pull_request_target')
     steps:
-      - uses: amannn/action-semantic-pull-request@v5.4.0
+      - uses: amannn/action-semantic-pull-request@e9fabac35e210fea40ca5b14c0da95a099eff26f
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,7 +17,7 @@ jobs:
                   github.event.pull_request.head.repo.full_name == github.repository }}
     steps:
       - name: configure aws credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a
         with:
           role-to-assume: ${{ secrets.IAM_ROLE_GITHUB }}
           aws-region: ${{ secrets.AWS_REGION }}

--- a/.github/workflows/upgrade-main.yml
+++ b/.github/workflows/upgrade-main.yml
@@ -64,7 +64,7 @@ jobs:
           git config user.email "github-actions@github.com"
       - name: Create Pull Request
         id: create-pr
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: |-

--- a/.github/workflows/website-deploy.yml
+++ b/.github/workflows/website-deploy.yml
@@ -34,7 +34,7 @@ jobs:
       # Popular action to deploy to GitHub Pages:
       # Docs: https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-docusaurus
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@373f7f263a76c20808c831209c920827a82a2847  # v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           # Build output to publish to the `gh-pages` branch:

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -76,6 +76,26 @@ const project = new awscdk.AwsCdkConstructLibrary({
   releaseTagPrefix: '@cdklabs/sbt-aws-',
 });
 
+// Pin third-party GitHub Actions to full commit SHAs. Mutable tags (@v4 etc.)
+// can be retagged, which is a supply-chain risk. These overrides are applied by
+// projen during synthesis to every generated workflow that uses the action, so
+// they survive `npx projen` regeneration (a direct edit to the generated YAML
+// would be reverted by the build's self-mutation check). Official actions/* are
+// left on tags, matching the maintainer preference. The version tag is kept in
+// the comment here for traceability.
+project.github?.actions.set(
+  'aws-actions/configure-aws-credentials@v4',
+  'aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a' // v4
+);
+project.github?.actions.set(
+  'peter-evans/create-pull-request@v6',
+  'peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c' // v6
+);
+project.github?.actions.set(
+  'amannn/action-semantic-pull-request@v5.4.0',
+  'amannn/action-semantic-pull-request@e9fabac35e210fea40ca5b14c0da95a099eff26f' // v5.4.0
+);
+
 // Add License header automatically
 project.eslint?.addPlugins('license-header');
 project.eslint?.addRules({


### PR DESCRIPTION
## Why

Pins all third-party GitHub Actions still referenced by mutable tags to full commit SHAs. Mutable tags (`@v4`, `@v3`, …) can be silently retagged — a supply-chain risk. Commit SHAs are immutable.

This extends the effort started in #209. **It also supersedes #209:** this repo is projen-managed, and #209 edits the *generated* workflow YAML directly, which the build's self-mutation check reverts (its `build` job fails for that reason). The correct fix routes through `.projenrc.ts`.

## How

This repo generates most workflows from `.projenrc.ts` (they carry a `~~ Generated by projen ~~` header). For those, pinning is done with projen's `project.github.actions.set(action, override)`, applied at synth time to every generated workflow that uses the action — so it survives `npx projen`. The one custom (non-projen) workflow, `website-deploy.yml`, is pinned directly.

## Pins

| Action | SHA | File | Notes |
|---|---|---|---|
| `aws-actions/configure-aws-credentials@v4` | `7474bc4690e2…` | `run-tests.yml` | via projen |
| `peter-evans/create-pull-request@v6` | `c5a7806660ad…` | `upgrade-main.yml` | via projen |
| `amannn/action-semantic-pull-request@v5.4.0` | `e9fabac35e21…` | `pull-request-lint.yml` | via projen |
| `peaceiris/actions-gh-pages@v3` | `373f7f263a76…` | `website-deploy.yml` | direct (custom file); runs with `contents: write` and pushes to `gh-pages`, so highest-value to pin |

All SHAs were verified against the upstream repos as the commits their tags resolve to. Official `actions/*` are left on tags, matching the maintainer preference in #209. No behavioral change — same released versions.

Verified locally: `npx projen` produces zero drift, so the self-mutation check passes.

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the project license.*
